### PR TITLE
Enable build scan and coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,16 @@ sudo: required
 
 services: docker
 
+# specific cache configuration for gradle based builds
+# see: https://docs.travis-ci.com/user/languages/java/#caching
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+
 script:
   - ./tools/travis/build.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # OpenWhisk User Events
 
+[![Build Status](https://travis-ci.org/adobe-apiplatform/openwhisk-user-events.svg?branch=master)](https://travis-ci.org/adobe-apiplatform/openwhisk-user-events)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
+[![codecov](https://codecov.io/gh/adobe-apiplatform/openwhisk-user-events/branch/master/graph/badge.svg)](https://codecov.io/gh/adobe-apiplatform/openwhisk-user-events)
+
 This service connects to `events` topic and publishes the events to to various services like Prometheus, Datadog etc via 
 Kamon. Refer to [user specific metrics][1] on how to enable them
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ plugins {
     id 'scala'
     id 'application'
     id "org.scoverage" version "2.5.0"
+    id "com.gradle.build-scan" version "1.14"
 }
 
 
@@ -24,6 +25,21 @@ sourceCompatibility = 1.8
 
 repositories {
     mavenCentral()
+}
+
+buildScan {
+    termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
+    publishAlwaysIf(System.getenv('CI') != null)
+}
+
+tasks.withType(Test) {
+    testLogging {
+        events "passed", "skipped", "failed"
+        showStandardStreams = true
+        exceptionFormat = 'full'
+    }
+    outputs.upToDateWhen { false } // force tests to run every time
 }
 
 
@@ -65,8 +81,6 @@ dependencies {
 tasks.withType(ScalaCompile) {
     scalaCompileOptions.additionalParameters = gradle.scala.compileFlags
 }
-
-
 
 
 mainClassName = 'com.adobe.api.platform.runtime.metrics.OpenWhiskEvents'

--- a/build.gradle
+++ b/build.gradle
@@ -15,11 +15,13 @@ plugins {
     id 'application'
     id "org.scoverage" version "2.5.0"
     id "com.gradle.build-scan" version "1.14"
+    id "cz.alenkacz.gradle.scalafmt" version "1.5.1"
 }
 
 
 group 'com.adobe.api.platform.runtime'
 version '1.0-SNAPSHOT'
+scalafmt.configFilePath = gradle.scalafmt.config
 
 sourceCompatibility = 1.8
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,6 +18,5 @@ gradle.ext.scala = [
 ]
 
 gradle.ext.scalafmt = [
-    version: '1.5.1',
     config: new File(rootProject.projectDir, '.scalafmt.conf')
 ]

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/EventMessage.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/EventMessage.scala
@@ -8,7 +8,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
-*/
+ */
 
 package com.adobe.api.platform.runtime.metrics
 

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonConsumer.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonConsumer.scala
@@ -8,7 +8,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
-*/
+ */
 
 package com.adobe.api.platform.runtime.metrics
 

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/OpenWhiskEvents.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/OpenWhiskEvents.scala
@@ -8,7 +8,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
-*/
+ */
 
 package com.adobe.api.platform.runtime.metrics
 

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/KafkaSpecBase.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/KafkaSpecBase.scala
@@ -8,7 +8,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
-*/
+ */
 
 package com.adobe.api.platform.runtime.metrics
 

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/KamonConsumerTests.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/KamonConsumerTests.scala
@@ -8,7 +8,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
-*/
+ */
 
 package com.adobe.api.platform.runtime.metrics
 

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -24,7 +24,7 @@ SECONDS=0
 SCRIPTDIR=$(cd $(dirname "$0") && pwd)
 ROOTDIR="$SCRIPTDIR/../.."
 
-./gradlew --console=plain --scan reportScoverage
+./gradlew --console=plain --scan checkScalafmtAll reportScoverage
 
 bash <(curl -s https://codecov.io/bash)
 echo "Time taken for ${0##*/} is $SECONDS secs"

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -15,9 +16,15 @@
 # limitations under the License.
 #
 
-sudo: required
+set -e
 
-services: docker
+# Build script for Travis-CI.
 
-script:
-  - ./tools/travis/build.sh
+SECONDS=0
+SCRIPTDIR=$(cd $(dirname "$0") && pwd)
+ROOTDIR="$SCRIPTDIR/../.."
+
+./gradlew --console=plain --scan reportScoverage
+
+bash <(curl -s https://codecov.io/bash)
+echo "Time taken for ${0##*/} is $SECONDS secs"


### PR DESCRIPTION
This PR enables

1. [Build Scan][1]
2. Code coverage and reporting to [Codecov][2]
3. Enable travis cache
4. Format check
5. Badges in readme

[1]: https://guides.gradle.org/creating-build-scans/
[2]: https://codecov.io/gh/adobe-apiplatform/openwhisk-user-events