### PR TITLE
Use akka http server and add health checks

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+
+ignore:
+  - "**/*Main.scala"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,4 @@
 
 ignore:
+  # Exclude the Main file as its not exercised by any test
   - "**/*Main.scala"

--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,7 @@ tasks.withType(ScalaCompile) {
 }
 
 
-mainClassName = 'com.adobe.api.platform.runtime.metrics.OpenWhiskEvents'
+mainClassName = 'com.adobe.api.platform.runtime.metrics.Main'
 
 //Ensure that dist archive name does not contain version
 distTar {

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,8 @@ dependencies {
     testCompile 'org.scalatest:scalatest_2.12:3.0.1'
     testCompile 'net.manub:scalatest-embedded-kafka_2.12:2.0.0'
     testCompile 'com.typesafe.akka:akka-testkit_2.12:2.5.17'
+    testCompile 'com.typesafe.akka:akka-stream-testkit_2.12:2.5.17'
+    testCompile 'com.typesafe.akka:akka-http-testkit_2.12:10.1.5'
 
     scoverage 'org.scoverage:scalac-scoverage-plugin_2.12:1.4.0-M4', 'org.scoverage:scalac-scoverage-runtime_2.12:1.4.0-M4'
 

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,9 @@ dependencies {
     compile ('io.kamon:kamon-core_2.12:1.1.3') {
         exclude group: 'com.lihaoyi'
     }
-    compile 'io.kamon:kamon-prometheus_2.12:1.1.1'
+    compile ('io.kamon:kamon-prometheus_2.12:1.1.1'){
+        exclude group: 'org.nanohttpd'
+    }
     compile 'io.kamon:kamon-datadog_2.12:1.0.0'
 
     testCompile 'junit:junit:4.11'

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -26,3 +26,8 @@ kamon.prometheus {
   # We expose the metrics endpoint over akka http. So default server is disabled
   start-embedded-http-server = no
 }
+
+user-metrics {
+  # Server port
+  port = 9095
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -27,7 +27,7 @@ kamon.prometheus {
   start-embedded-http-server = no
 }
 
-user-metrics {
+user-events {
   # Server port
   port = 9095
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -21,3 +21,8 @@ akka.kafka.consumer {
     bootstrap.servers = ${?KAFKA_HOSTS}
   }
 }
+
+kamon.prometheus {
+  # We expose the metrics endpoint over akka http. So default server is disabled
+  start-embedded-http-server = no
+}

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/EventsApi.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/EventsApi.scala
@@ -1,0 +1,40 @@
+/*
+Copyright 2018 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+ */
+
+package com.adobe.api.platform.runtime.metrics
+import java.nio.charset.StandardCharsets.UTF_8
+
+import akka.http.scaladsl.model.HttpEntity
+import akka.http.scaladsl.model.StatusCodes.ServiceUnavailable
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import com.adobe.api.platform.runtime.metrics.OpenWhiskEvents.textV4
+import kamon.prometheus.PrometheusReporter
+
+class EventsApi(consumer: KamonConsumer, prometheus: PrometheusReporter) {
+
+  val routes: Route = {
+    get {
+      path("ping") {
+        if (consumer.isRunning) {
+          complete("pong")
+        } else {
+          complete(ServiceUnavailable -> "Consumer not running")
+        }
+      } ~ path("metrics") {
+        encodeResponse {
+          complete(HttpEntity(textV4, prometheus.scrapeData().getBytes(UTF_8)))
+        }
+      }
+    }
+  }
+}

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonConsumer.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonConsumer.scala
@@ -33,6 +33,8 @@ case class KamonConsumer(settings: ConsumerSettings[String, String])(implicit sy
     control.drainAndShutdown()(system.dispatcher)
   }
 
+  def isRunning: Boolean = !control.isShutdown.isCompleted
+
   //TODO Use RestartSource
   private val control: DrainingControl[Done] = Consumer
     .committableSource(settings, Subscriptions.topics(userEventTopic))
@@ -45,6 +47,7 @@ case class KamonConsumer(settings: ConsumerSettings[String, String])(implicit sy
     .toMat(Sink.ignore)(Keep.both)
     .mapMaterializedValue(DrainingControl.apply)
     .run()
+
 }
 
 object KamonConsumer {

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonConsumer.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonConsumer.scala
@@ -61,7 +61,6 @@ object KamonConsumer {
         val a = e.body.asInstanceOf[Activation]
         Kamon.histogram("waitTime", MeasurementUnit.time.milliseconds).refine("name" -> a.name).record(a.waitTime)
         Kamon.counter("activations").refine("name" -> a.name).increment()
-        println(a.name)
       }
   }
 }

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/Main.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/Main.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adobe.api.platform.runtime.metrics
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.stream.ActorMaterializer
+import scala.concurrent.duration.DurationInt
+
+import scala.concurrent.{Await, ExecutionContextExecutor, Future}
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    implicit val system: ActorSystem = ActorSystem("events-actor-system")
+    implicit val materializer: ActorMaterializer = ActorMaterializer()
+    val binding = OpenWhiskEvents.start(system.settings.config)
+    addShutdownHook(binding)
+  }
+
+  private def addShutdownHook(binding: Future[Http.ServerBinding])(implicit actorSystem: ActorSystem,
+                                                                   materializer: ActorMaterializer): Unit = {
+    implicit val ec: ExecutionContextExecutor = actorSystem.dispatcher
+    sys.addShutdownHook {
+      Await.result(binding.map(_.unbind()), 30.seconds)
+      Await.result(actorSystem.whenTerminated, 30.seconds)
+    }
+  }
+}

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/OpenWhiskEvents.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/OpenWhiskEvents.scala
@@ -37,7 +37,7 @@ object OpenWhiskEvents extends SLF4JLogging {
   def main(args: Array[String]): Unit = {
     val prometheus = new PrometheusReporter()
     Kamon.addReporter(prometheus)
-    val metricConfig = loadConfigOrThrow[MetricConfig]("user-metrics")
+    val metricConfig = loadConfigOrThrow[MetricConfig]("user-events")
     implicit val system: ActorSystem = ActorSystem("runtime-actor-system")
     implicit val materializer: ActorMaterializer = ActorMaterializer()
     val port = metricConfig.port

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/OpenWhiskEvents.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/OpenWhiskEvents.scala
@@ -50,7 +50,9 @@ object OpenWhiskEvents extends SLF4JLogging {
           complete(503 -> "Consumer not running")
         }
       } ~ path("metrics") {
-        complete(HttpEntity(textV4, prometheus.scrapeData().getBytes(UTF_8)))
+        encodeResponse {
+          complete(HttpEntity(textV4, prometheus.scrapeData().getBytes(UTF_8)))
+        }
       }
     }
 

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/OpenWhiskEvents.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/OpenWhiskEvents.scala
@@ -41,7 +41,7 @@ object OpenWhiskEvents extends SLF4JLogging {
 
     implicit val system: ActorSystem = ActorSystem("runtime-actor-system")
     implicit val materializer: ActorMaterializer = ActorMaterializer()
-    val port = 9096 //TODO Make port configurable
+    val port = 9095 //TODO Make port configurable
     val kamonConsumer = KamonConsumer(eventConsumerSettings(defaultConsumerConfig(system)))
     val route = get {
       path("ping") {

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/OpenWhiskEvents.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/OpenWhiskEvents.scala
@@ -20,6 +20,7 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{ContentType, HttpEntity}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.model.StatusCodes.ServiceUnavailable
 import akka.kafka.ConsumerSettings
 import akka.stream.ActorMaterializer
 import com.typesafe.config.Config
@@ -47,7 +48,7 @@ object OpenWhiskEvents extends SLF4JLogging {
         if (kamonConsumer.isRunning) {
           complete("pong")
         } else {
-          complete(503 -> "Consumer not running")
+          complete(ServiceUnavailable -> "Consumer not running")
         }
       } ~ path("metrics") {
         encodeResponse {

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/ApiTests.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/ApiTests.scala
@@ -1,0 +1,58 @@
+/*
+Copyright 2018 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+ */
+
+package com.adobe.api.platform.runtime.metrics
+import akka.http.scaladsl.model.{HttpCharsets, HttpResponse}
+import akka.http.scaladsl.model.headers.HttpEncodings._
+import akka.http.scaladsl.model.headers.{`Accept-Encoding`, `Content-Encoding`, HttpEncoding, HttpEncodings}
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import kamon.prometheus.PrometheusReporter
+import org.junit.runner.RunWith
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.matchers.Matcher
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.duration.DurationInt
+
+@RunWith(classOf[JUnitRunner])
+class ApiTests extends FlatSpec with Matchers with ScalatestRouteTest with EventsTestHelper with ScalaFutures {
+  implicit val timeoutConfig = PatienceConfig(1.minute)
+  behavior of "EventsApi"
+
+  it should "respond ping request" in {
+    val consumer = createConsumer(56754)
+    val api = new EventsApi(consumer, new PrometheusReporter)
+    Get("/ping") ~> api.routes ~> check {
+      //Due to retries using a random port does not immediately result in failure
+      handled shouldBe true
+    }
+    consumer.shutdown().futureValue
+  }
+
+  it should "respond metrics request" in {
+    val consumer = createConsumer(56754)
+    val api = new EventsApi(consumer, new PrometheusReporter)
+    Get("/metrics") ~> `Accept-Encoding`(gzip) ~> api.routes ~> check {
+      contentType.charsetOption shouldBe Some(HttpCharsets.`UTF-8`)
+      contentType.mediaType.params("version") shouldBe "0.0.4"
+      response should haveContentEncoding(gzip)
+    }
+    consumer.shutdown().futureValue
+  }
+
+  private def haveContentEncoding(encoding: HttpEncoding): Matcher[HttpResponse] =
+    be(encoding) compose {
+      (_: HttpResponse).header[`Content-Encoding`].map(_.encodings.head).getOrElse(HttpEncodings.identity)
+    }
+
+}

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/ApiTests.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/ApiTests.scala
@@ -11,9 +11,9 @@ governing permissions and limitations under the License.
  */
 
 package com.adobe.api.platform.runtime.metrics
-import akka.http.scaladsl.model.{HttpCharsets, HttpResponse}
 import akka.http.scaladsl.model.headers.HttpEncodings._
 import akka.http.scaladsl.model.headers.{`Accept-Encoding`, `Content-Encoding`, HttpEncoding, HttpEncodings}
+import akka.http.scaladsl.model.{HttpCharsets, HttpResponse}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import kamon.prometheus.PrometheusReporter
 import org.junit.runner.RunWith
@@ -22,15 +22,12 @@ import org.scalatest.junit.JUnitRunner
 import org.scalatest.matchers.Matcher
 import org.scalatest.{FlatSpec, Matchers}
 
-import scala.concurrent.duration.DurationInt
-
 @RunWith(classOf[JUnitRunner])
 class ApiTests extends FlatSpec with Matchers with ScalatestRouteTest with EventsTestHelper with ScalaFutures {
-  implicit val timeoutConfig = PatienceConfig(1.minute)
   behavior of "EventsApi"
 
   it should "respond ping request" in {
-    val consumer = createConsumer(56754)
+    val consumer = createConsumer(56754, system.settings.config)
     val api = new EventsApi(consumer, new PrometheusReporter)
     Get("/ping") ~> api.routes ~> check {
       //Due to retries using a random port does not immediately result in failure
@@ -40,7 +37,7 @@ class ApiTests extends FlatSpec with Matchers with ScalatestRouteTest with Event
   }
 
   it should "respond metrics request" in {
-    val consumer = createConsumer(56754)
+    val consumer = createConsumer(56754, system.settings.config)
     val api = new EventsApi(consumer, new PrometheusReporter)
     Get("/metrics") ~> `Accept-Encoding`(gzip) ~> api.routes ~> check {
       contentType.charsetOption shouldBe Some(HttpCharsets.`UTF-8`)

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/EventsTestHelper.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/EventsTestHelper.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adobe.api.platform.runtime.metrics
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+
+trait EventsTestHelper {
+
+  protected def createConsumer(kport: Int)(implicit system: ActorSystem, materializer: ActorMaterializer) = {
+    val settings = OpenWhiskEvents
+      .eventConsumerSettings(OpenWhiskEvents.defaultConsumerConfig(system))
+      .withBootstrapServers(s"localhost:$kport")
+    KamonConsumer(settings)
+  }
+}

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/EventsTestHelper.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/EventsTestHelper.scala
@@ -16,15 +16,25 @@
  */
 
 package com.adobe.api.platform.runtime.metrics
+import java.net.ServerSocket
+
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+import com.typesafe.config.Config
 
 trait EventsTestHelper {
 
-  protected def createConsumer(kport: Int)(implicit system: ActorSystem, materializer: ActorMaterializer) = {
+  protected def createConsumer(kport: Int, globalConfig: Config)(implicit system: ActorSystem,
+                                                                 materializer: ActorMaterializer) = {
     val settings = OpenWhiskEvents
-      .eventConsumerSettings(OpenWhiskEvents.defaultConsumerConfig(system))
+      .eventConsumerSettings(OpenWhiskEvents.defaultConsumerConfig(globalConfig))
       .withBootstrapServers(s"localhost:$kport")
     KamonConsumer(settings)
+  }
+
+  protected def freePort(): Int = {
+    val socket = new ServerSocket(0)
+    try socket.getLocalPort
+    finally if (socket != null) socket.close()
   }
 }

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/KafkaSpecBase.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/KafkaSpecBase.scala
@@ -17,7 +17,7 @@ import akka.stream.ActorMaterializer
 import akka.testkit.TestKit
 import net.manub.embeddedkafka.EmbeddedKafka
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
-import org.scalatest.{FlatSpecLike, Matchers, Suite}
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers, Suite}
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.concurrent.duration.FiniteDuration
@@ -30,7 +30,9 @@ abstract class KafkaSpecBase
     with FlatSpecLike
     with EmbeddedKafka
     with IntegrationPatience
-    with Eventually { this: Suite =>
+    with BeforeAndAfterAll
+    with Eventually
+    with EventsTestHelper { this: Suite =>
   val log: Logger = LoggerFactory.getLogger(getClass)
 
   implicit val materializer = ActorMaterializer()
@@ -38,5 +40,10 @@ abstract class KafkaSpecBase
   def sleep(time: FiniteDuration, msg: String = ""): Unit = {
     log.info(s"sleeping $time $msg")
     Thread.sleep(time.toMillis)
+  }
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+    shutdown()
   }
 }

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/KafkaSpecBase.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/KafkaSpecBase.scala
@@ -14,6 +14,7 @@ package com.adobe.api.platform.runtime.metrics
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+import scala.concurrent.duration.DurationInt
 import akka.testkit.TestKit
 import net.manub.embeddedkafka.EmbeddedKafka
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
@@ -34,6 +35,7 @@ abstract class KafkaSpecBase
     with Eventually
     with EventsTestHelper { this: Suite =>
   val log: Logger = LoggerFactory.getLogger(getClass)
+  implicit val timeoutConfig = PatienceConfig(1.minute)
 
   implicit val materializer = ActorMaterializer()
 

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/KamonConsumerTests.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/KamonConsumerTests.scala
@@ -64,13 +64,6 @@ class KamonConsumerTests extends KafkaSpecBase with BeforeAndAfterEach {
     }
   }
 
-  private def createConsumer(kport: Int) = {
-    val settings = OpenWhiskEvents
-      .eventConsumerSettings(OpenWhiskEvents.defaultConsumerConfig(system))
-      .withBootstrapServers(s"localhost:$kport")
-    KamonConsumer(settings)
-  }
-
   private def newActivationEvent(name: String, kind: String = "nodejs") =
     EventMessage(
       "test",

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/KamonConsumerTests.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/KamonConsumerTests.scala
@@ -55,7 +55,7 @@ class KamonConsumerTests extends KafkaSpecBase with BeforeAndAfterEach {
     val kconfig = EmbeddedKafkaConfig(kafkaPort = 0, zooKeeperPort = 0)
     withRunningKafkaOnFoundPort(kconfig) { implicit actualConfig =>
       createCustomTopic(KamonConsumer.userEventTopic)
-      val consumer = createConsumer(actualConfig.kafkaPort)
+      val consumer = createConsumer(actualConfig.kafkaPort, system.settings.config)
       publishStringMessageToKafka(KamonConsumer.userEventTopic, newActivationEvent("a1").serialize)
       sleep(sleepAfterProduce, "sleeping post produce")
       consumer.shutdown().futureValue

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/OpenWhiskEventsTests.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/OpenWhiskEventsTests.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adobe.api.platform.runtime.metrics
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.{HttpRequest, StatusCodes}
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import com.typesafe.config.ConfigFactory
+import net.manub.embeddedkafka.EmbeddedKafkaConfig
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scala.util.Try
+
+@RunWith(classOf[JUnitRunner])
+class OpenWhiskEventsTests extends KafkaSpecBase {
+  behavior of "Server"
+
+  it should "start working http server" in {
+    val kconfig = EmbeddedKafkaConfig(kafkaPort = 0, zooKeeperPort = 0)
+    withRunningKafkaOnFoundPort(kconfig) { implicit actualConfig =>
+      val kafkaPort = actualConfig.kafkaPort
+      val httpPort = freePort()
+      val globalConfig = system.settings.config
+      val config = ConfigFactory.parseString(s"""
+           | akka.kafka.consumer.kafka-clients {
+           |  bootstrap.servers = "localhost:$kafkaPort"
+           | }
+           | 
+           | user-events {
+           |  port = $httpPort
+           | }
+         """.stripMargin).withFallback(globalConfig)
+
+      val binding = OpenWhiskEvents.start(config).futureValue
+      val res = ping("localhost", httpPort, "/ping")
+      res shouldBe Some(StatusCodes.OK, "pong")
+      binding.unbind().futureValue
+    }
+  }
+
+  def ping(host: String, port: Int, path: String = "/") = {
+    val response = Try {
+      Http()
+        .singleRequest(HttpRequest(uri = s"http://$host:$port$path"))
+        .futureValue
+    }.toOption
+
+    response.map { res =>
+      (res.status, Unmarshal(res).to[String].futureValue)
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces following major changes

1. Expose the `/metrics` endpoint over Akka HTTP server instead of the embedded nano http server used by [Prometheus reporter][2]. The response here confirm to the [specified exposition format][1] i.e. they support `gzip` compression and also v 0.0.4 header
2. Expose a health check endpoint`/ping` which would respond with `/pong` if the backing consumer stream is working. This ensures that if for some reason streams fails the container orchestrator can restart the service

[1]: https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md
[2]: https://github.com/kamon-io/kamon-prometheus
