### PR TITLE
Match metric names per convention

### DIFF
--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonRecorder.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonRecorder.scala
@@ -13,13 +13,21 @@ governing permissions and limitations under the License.
 package com.adobe.api.platform.runtime.metrics
 
 import com.adobe.api.platform.runtime.metrics.Activation.getNamespaceAndActionName
-import com.adobe.api.platform.runtime.metrics.MetricNames._
 import kamon.Kamon
 import kamon.metric.MeasurementUnit
 
 import scala.collection.concurrent.TrieMap
 
-object KamonRecorder extends MetricRecorder {
+trait KamonMetricNames extends MetricNames {
+  val activationMetric = "openwhisk.action.activations"
+  val coldStartMetric = "openwhisk.action.coldStarts"
+  val waitTimeMetric = "openwhisk.action.waitTime"
+  val initTimeMetric = "openwhisk.action.initTime"
+  val durationMetric = "openwhisk.action.duration"
+  val statusMetric = "openwhisk.action.status"
+}
+
+object KamonRecorder extends MetricRecorder with KamonMetricNames {
   private val metrics = new TrieMap[String, KamonMetrics]
 
   def processEvent(activation: Activation): Unit = {
@@ -34,7 +42,7 @@ object KamonRecorder extends MetricRecorder {
   }
 
   case class KamonMetrics(namespace: String, action: String) {
-    private val tags = Map("namespace" -> namespace, "action" -> action)
+    private val tags = Map(`actionNamespace` -> namespace, `actionName` -> action)
 
     private val activations = Kamon.counter(activationMetric).refine(tags)
     private val coldStarts = Kamon.counter(coldStartMetric).refine(tags)

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/MetricNames.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/MetricNames.scala
@@ -12,11 +12,14 @@ governing permissions and limitations under the License.
 
 package com.adobe.api.platform.runtime.metrics
 
-object MetricNames {
-  val activationMetric = "openwhisk_action_activations"
-  val coldStartMetric = "openwhisk_action_coldStarts"
-  val waitTimeMetric = "openwhisk_action_waitTime"
-  val initTimeMetric = "openwhisk_action_initTime"
-  val durationMetric = "openwhisk_action_duration"
-  val statusMetric = "openwhisk_action_status"
+trait MetricNames {
+  val actionNamespace = "namespace"
+  val actionName = "action"
+
+  def activationMetric: String
+  def coldStartMetric: String
+  def waitTimeMetric: String
+  def initTimeMetric: String
+  def durationMetric: String
+  def statusMetric: String
 }

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/KamonRecorderTests.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/KamonRecorderTests.scala
@@ -22,12 +22,11 @@ import net.manub.embeddedkafka.EmbeddedKafkaConfig
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.junit.JUnitRunner
-import com.adobe.api.platform.runtime.metrics.MetricNames._
 
 import scala.concurrent.duration._
 
 @RunWith(classOf[JUnitRunner])
-class KamonRecorderTests extends KafkaSpecBase with BeforeAndAfterEach {
+class KamonRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with KamonMetricNames {
   val sleepAfterProduce: FiniteDuration = 4.seconds
   var reporterReg: Registration = _
 
@@ -119,7 +118,7 @@ class KamonRecorderTests extends KafkaSpecBase with BeforeAndAfterEach {
     override def stop(): Unit = {}
     override def reconfigure(config: Config): Unit = {}
 
-    def reset() = {
+    def reset(): Unit = {
       snapshotAccumulator = new PeriodSnapshotAccumulator(Duration.ofDays(1), Duration.ZERO)
     }
 

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorderTests.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorderTests.scala
@@ -12,7 +12,6 @@ governing permissions and limitations under the License.
 
 package com.adobe.api.platform.runtime.metrics
 
-import com.adobe.api.platform.runtime.metrics.MetricNames._
 import io.prometheus.client.CollectorRegistry
 import net.manub.embeddedkafka.EmbeddedKafkaConfig
 import org.junit.runner.RunWith
@@ -22,7 +21,7 @@ import org.scalatest.junit.JUnitRunner
 import scala.concurrent.duration._
 
 @RunWith(classOf[JUnitRunner])
-class PrometheusRecorderTests extends KafkaSpecBase with BeforeAndAfterEach {
+class PrometheusRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with PrometheusMetricNames {
   val sleepAfterProduce: FiniteDuration = 4.seconds
 
   behavior of "PrometheusConsumer"


### PR DESCRIPTION
As discussed in #5 this PR extracts the naming logic as trait and enables adapting the names as per metric system convention. For Prometheus the names use `_` and follow [certain convention] while for others they use dot `.` 

[1]: https://prometheus.io/docs/practices/naming/#metric-names