### PR TITLE
Reenable Kamon PrometheusReporter for non action metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,9 @@ dependencies {
     compile ('io.kamon:kamon-core_2.12:1.1.3') {
         exclude group: 'com.lihaoyi'
     }
+    compile ('io.kamon:kamon-prometheus_2.12:1.1.1'){
+        exclude group: 'org.nanohttpd'
+    }
     compile 'io.kamon:kamon-datadog_2.12:1.0.0'
     compile 'io.prometheus:simpleclient:0.6.0'
     compile 'io.prometheus:simpleclient_common:0.6.0'

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -22,6 +22,11 @@ akka.kafka.consumer {
   }
 }
 
+kamon.prometheus {
+  # We expose the metrics endpoint over akka http. So default server is disabled
+  start-embedded-http-server = no
+}
+
 user-events {
   # Server port
   port = 9095

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/EventsTestHelper.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/EventsTestHelper.scala
@@ -16,10 +16,13 @@ import java.net.ServerSocket
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.Config
+import kamon.prometheus.PrometheusReporter
 
 trait EventsTestHelper {
 
-  protected def createConsumer(kport: Int, globalConfig: Config, recorder: MetricRecorder = PrometheusRecorder)(
+  protected def createConsumer(kport: Int,
+                               globalConfig: Config,
+                               recorder: MetricRecorder = PrometheusRecorder(new PrometheusReporter))(
     implicit system: ActorSystem,
     materializer: ActorMaterializer) = {
     val settings = OpenWhiskEvents

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/KafkaSpecBase.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/KafkaSpecBase.scala
@@ -14,16 +14,13 @@ package com.adobe.api.platform.runtime.metrics
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-
-import scala.concurrent.duration.DurationInt
 import akka.testkit.TestKit
-import io.prometheus.client.CollectorRegistry
 import net.manub.embeddedkafka.EmbeddedKafka
-import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest._
+import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.slf4j.{Logger, LoggerFactory}
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
 abstract class KafkaSpecBase
     extends TestKit(ActorSystem("test"))
@@ -45,11 +42,6 @@ abstract class KafkaSpecBase
   def sleep(time: FiniteDuration, msg: String = ""): Unit = {
     log.info(s"sleeping $time $msg")
     Thread.sleep(time.toMillis)
-  }
-
-  override protected def beforeEach(): Unit = {
-    super.beforeEach()
-    CollectorRegistry.defaultRegistry.clear()
   }
 
   override protected def afterAll(): Unit = {

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/KafkaSpecBase.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/KafkaSpecBase.scala
@@ -14,11 +14,13 @@ package com.adobe.api.platform.runtime.metrics
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+
 import scala.concurrent.duration.DurationInt
 import akka.testkit.TestKit
+import io.prometheus.client.CollectorRegistry
 import net.manub.embeddedkafka.EmbeddedKafka
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers, Suite}
+import org.scalatest._
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.concurrent.duration.FiniteDuration
@@ -32,6 +34,7 @@ abstract class KafkaSpecBase
     with EmbeddedKafka
     with IntegrationPatience
     with BeforeAndAfterAll
+    with BeforeAndAfterEach
     with Eventually
     with EventsTestHelper { this: Suite =>
   val log: Logger = LoggerFactory.getLogger(getClass)
@@ -42,6 +45,11 @@ abstract class KafkaSpecBase
   def sleep(time: FiniteDuration, msg: String = ""): Unit = {
     log.info(s"sleeping $time $msg")
     Thread.sleep(time.toMillis)
+  }
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    CollectorRegistry.defaultRegistry.clear()
   }
 
   override protected def afterAll(): Unit = {


### PR DESCRIPTION
This PR re-enables the Kamon PrometheusReporter alongside with Prometheus Java Client (#5). This allows using Kamon API to record metrics which are not related to specific action and hence generic. 

As such metrics would be bounded its safe to use the Kamon route for them. Thus we can use single api to send the metrics to either Prometheus specifically or any other Kamon supported backend