### PR TITLE
Count successful invocations too

### DIFF
--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonRecorder.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonRecorder.scala
@@ -62,9 +62,7 @@ object KamonRecorder extends MetricRecorder with KamonMetricNames {
       waitTime.record(a.waitTime)
       duration.record(a.duration)
 
-      if (a.statusCode != 0) {
-        Kamon.counter(statusMetric).refine(tags + ("status" -> a.status)).increment()
-      }
+      Kamon.counter(statusMetric).refine(tags + ("status" -> a.status)).increment()
     }
   }
 }

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorder.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorder.scala
@@ -61,6 +61,11 @@ case class PrometheusRecorder(kamon: PrometheusReporter) extends MetricRecorder 
     private val initTime = initTimeHisto.labels(namespace, action)
     private val duration = durationHisto.labels(namespace, action)
 
+    private val statusSuccess = statusCounter.labels(namespace, action, Activation.statusSuccess)
+    private val statusApplicationError = statusCounter.labels(namespace, action, Activation.statusApplicationError)
+    private val statusDeveloperError = statusCounter.labels(namespace, action, Activation.statusDeveloperError)
+    private val statusInternalError = statusCounter.labels(namespace, action, Activation.statusInternalError)
+
     def record(a: Activation): Unit = {
       activations.inc()
 
@@ -73,7 +78,13 @@ case class PrometheusRecorder(kamon: PrometheusReporter) extends MetricRecorder 
       waitTime.observe(seconds(a.waitTime))
       duration.observe(seconds(a.duration))
 
-      statusCounter.labels(namespace, action, a.status).inc()
+      a.status match {
+        case Activation.statusSuccess          => statusSuccess.inc()
+        case Activation.statusApplicationError => statusApplicationError.inc()
+        case Activation.statusDeveloperError   => statusDeveloperError.inc()
+        case Activation.statusInternalError    => statusInternalError.inc()
+        case x                                 => statusCounter.labels(namespace, action, x).inc()
+      }
     }
   }
 

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorder.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorder.scala
@@ -73,9 +73,7 @@ case class PrometheusRecorder(kamon: PrometheusReporter) extends MetricRecorder 
       waitTime.observe(seconds(a.waitTime))
       duration.observe(seconds(a.duration))
 
-      if (a.statusCode != 0) {
-        statusCounter.labels(namespace, action, a.status).inc()
-      }
+      statusCounter.labels(namespace, action, a.status).inc()
     }
   }
 


### PR DESCRIPTION
This PR Fixes #15 and allows the count of successful invocation with the `openwhisk_action_status` metric.