### PR TITLE
Add default Grafana dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,14 @@ Integrations
 The docker container would run the service and expose the metrics in format required by Prometheus at `9095` port
 
 #### Grafana
-The `Openwhisk - Action Performance Metrics` grafana dashboard is available on port `3000` at this address: 
-[http://localhost:3000/d/Oew1lvymk/openwhisk-action-performance-metrics](http://localhost:3000/d/Oew1lvymk/openwhisk-action-performance-metrics)
+The `Openwhisk - Action Performance Metrics` grafana dashboard is available on localhost port `3000` at this address: 
+[http://localhost:3000/d/Oew1lvymk/openwhisk-action-performance-metrics][5]
+
+The latest version of the dashboard can be found on [Grafana Labs][6].
 
 [1]: https://github.com/apache/incubator-openwhisk/blob/master/docs/metrics.md#user-specific-metrics
 [2]: https://github.com/apache/incubator-openwhisk-devtools/tree/master/docker-compose
 [3]: https://hub.docker.com/r/prom/prometheus/
 [4]: https://hub.docker.com/r/grafana/grafana/
+[5]: http://localhost:3000/d/Oew1lvymk/openwhisk-action-performance-metrics
+[6]: https://grafana.com/dashboards/9564

--- a/README.md
+++ b/README.md
@@ -11,23 +11,22 @@ This service connects to `events` topic and publishes the events to various serv
 This command pulls the docker images for local testing and development.
 
 ```bash
-make docker-build
+make all
 ```
 
 ## Run
-The container will be run inside the openwhisk [docker-compose][2] environment
-
 ```bash
-make run
+make start-docker-compose
 ```
 
-This command would starts the user-events service along with [Prometheus][4] and Grafana[5]
+This command will start the `user-event` service along with [prometheus][3] and [grafana][4] inside the same [docker-compose openwhisk][2] network. 
+
 
 These ports must be available:
 
 - `9095` - user-events service
 - `9096` - prometheus
-- `3000` - Grafana
+- `3000` - grafana
 
 ## Logs
 
@@ -39,5 +38,11 @@ Integrations
 #### Prometheus
 The docker container would run the service and expose the metrics in format required by Prometheus at `9095` port
 
+#### Grafana
+The `Openwhisk - Action Performance Metrics` grafana dashboard is available on port `3000` at this address: 
+[http://localhost:3000/d/Oew1lvymk/openwhisk-action-performance-metrics](http://localhost:3000/d/Oew1lvymk/openwhisk-action-performance-metrics)
+
 [1]: https://github.com/apache/incubator-openwhisk/blob/master/docs/metrics.md#user-specific-metrics
 [2]: https://github.com/apache/incubator-openwhisk-devtools/tree/master/docker-compose
+[3]: https://hub.docker.com/r/prom/prometheus/
+[4]: https://hub.docker.com/r/grafana/grafana/

--- a/compose/grafana/dashboards/openwhisk_events.json
+++ b/compose/grafana/dashboards/openwhisk_events.json
@@ -1,30 +1,4 @@
 {
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "5.3.2"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": "5.0.0"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "5.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "singlestat",
-      "name": "Singlestat",
-      "version": "5.0.0"
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -42,16 +16,346 @@
   "editable": true,
   "gnetId": 9564,
   "graphTooltip": 0,
-  "iteration": 1546902968917,
+  "iteration": 1546951304014,
   "links": [],
   "panels": [
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": null,
+      "decimals": 0,
+      "description": "Total number of activation in the selected time interval",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 28,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(249, 186, 143, 0.15)",
+        "full": false,
+        "lineColor": "#ef843c",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(increase(openwhisk_action_activations_total{namespace=~\"$namespace\",action=~\"$action\"}[$interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Total activations",
+      "type": "singlestat",
+      "valueFontSize": "100%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "rgba(212, 74, 58, 0)",
+        "#508642",
+        "#299c46"
+      ],
+      "datasource": null,
+      "decimals": 0,
+      "description": "Total number of successful activations executed",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 32,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(136, 253, 150, 0.18)",
+        "full": false,
+        "lineColor": "#7eb26d",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(increase(openwhisk_action_status{namespace=~\"$namespace\",action=~\"$action\",status=\"success\"}[$interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "1",
+      "title": "Successful activations",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorPostfix": false,
+      "colorPrefix": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(41, 156, 70, 0)",
+        "#e24d42",
+        "#e24d42"
+      ],
+      "datasource": null,
+      "decimals": 0,
+      "description": "Total number of error activations in the selected time interval",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 34,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgb(243, 113, 104)",
+        "full": false,
+        "lineColor": "rgb(255, 194, 190)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(increase(openwhisk_action_status{namespace=~\"$namespace\",action=~\"$action\",status!=\"success\"}[$interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "1",
+      "title": "Error activations",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "rgba(41, 156, 70, 0)",
+        "#1f78c1",
+        "#1f78c1"
+      ],
+      "datasource": null,
+      "decimals": 0,
+      "description": "Total number of cold starts in the selected time interval",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 30,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(81, 149, 206, 0.48)",
+        "full": false,
+        "lineColor": "rgb(122, 181, 231)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(increase(openwhisk_action_coldStarts_total{namespace=~\"$namespace\",action=~\"$action\"}[$interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "1",
+      "title": "Cold starts",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
     {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 2
       },
       "id": 16,
       "panels": [],
@@ -80,7 +384,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 1
+        "y": 3
       },
       "id": 6,
       "interval": null,
@@ -137,7 +441,7 @@
           "value": "null"
         }
       ],
-      "valueName": "avg"
+      "valueName": "current"
     },
     {
       "cacheTimeout": null,
@@ -161,7 +465,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 1
+        "y": 3
       },
       "id": 8,
       "interval": null,
@@ -219,7 +523,7 @@
           "value": "null"
         }
       ],
-      "valueName": "avg"
+      "valueName": "current"
     },
     {
       "cacheTimeout": null,
@@ -243,7 +547,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 1
+        "y": 3
       },
       "id": 26,
       "interval": null,
@@ -300,14 +604,14 @@
           "value": "null"
         }
       ],
-      "valueName": "avg"
+      "valueName": "current"
     },
     {
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 7
+        "y": 9
       },
       "id": 14,
       "title": "Activation result graph",
@@ -324,7 +628,7 @@
         "h": 9,
         "w": 8,
         "x": 0,
-        "y": 8
+        "y": 10
       },
       "id": 4,
       "legend": {
@@ -410,7 +714,7 @@
         "h": 9,
         "w": 8,
         "x": 8,
-        "y": 8
+        "y": 10
       },
       "id": 18,
       "legend": {
@@ -497,7 +801,7 @@
         "h": 9,
         "w": 8,
         "x": 16,
-        "y": 8
+        "y": 10
       },
       "id": 20,
       "legend": {
@@ -578,7 +882,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 19
       },
       "id": 12,
       "panels": [],
@@ -596,7 +900,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 20
       },
       "id": 22,
       "legend": {
@@ -684,7 +988,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 28
       },
       "id": 10,
       "panels": [],
@@ -702,7 +1006,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 29
       },
       "id": 24,
       "legend": {
@@ -789,7 +1093,7 @@
         "allValue": null,
         "current": {
           "text": "All",
-          "value": "All"
+          "value": "$__all"
         },
         "datasource": null,
         "definition": "label_values(openwhisk_action_activations_total,namespace)",
@@ -813,8 +1117,9 @@
       {
         "allValue": "",
         "current": {
+          "tags": [],
           "text": "All",
-          "value": "All"
+          "value": "$__all"
         },
         "datasource": null,
         "definition": "label_values(openwhisk_counter_container_activations_total,action)",
@@ -834,6 +1139,79 @@
         "tagsQuery": "",
         "type": "query",
         "useTags": false
+      },
+      {
+        "auto": true,
+        "auto_count": 1,
+        "auto_min": "1m",
+        "current": {
+          "text": "auto",
+          "value": "$__auto_interval_interval"
+        },
+        "hide": 2,
+        "label": null,
+        "name": "interval",
+        "options": [
+          {
+            "selected": true,
+            "text": "auto",
+            "value": "$__auto_interval_interval"
+          },
+          {
+            "selected": false,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          },
+          {
+            "selected": false,
+            "text": "1h",
+            "value": "1h"
+          },
+          {
+            "selected": false,
+            "text": "6h",
+            "value": "6h"
+          },
+          {
+            "selected": false,
+            "text": "12h",
+            "value": "12h"
+          },
+          {
+            "selected": false,
+            "text": "1d",
+            "value": "1d"
+          },
+          {
+            "selected": false,
+            "text": "7d",
+            "value": "7d"
+          },
+          {
+            "selected": false,
+            "text": "14d",
+            "value": "14d"
+          },
+          {
+            "selected": false,
+            "text": "30d",
+            "value": "30d"
+          }
+        ],
+        "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+        "refresh": 2,
+        "skipUrlSync": false,
+        "type": "interval"
       }
     ]
   },
@@ -869,5 +1247,5 @@
   "timezone": "",
   "title": "Openwhisk - Action Performance Metrics",
   "uid": "Oew1lvymk",
-  "version": 1
+  "version": 2
 }

--- a/compose/grafana/dashboards/openwhisk_events.json
+++ b/compose/grafana/dashboards/openwhisk_events.json
@@ -1,0 +1,873 @@
+{
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "5.3.2"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": "5.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "5.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": "5.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Action performance metrics available for the users of Openwhisk.",
+  "editable": true,
+  "gnetId": 9564,
+  "graphTooltip": 0,
+  "iteration": 1546902968917,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 16,
+      "panels": [],
+      "title": "General gauges",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(237, 129, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": null,
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": true,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "id": 6,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(sum(increase(openwhisk_action_status{namespace=~\"$Namespace\",action=~\"$Action\",status=\"success\"}[1m])) by (action)) * 100 / sum(sum(increase(openwhisk_action_status{namespace=~\"$Namespace\",action=~\"$Action\"}[1m])) by (action))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A",
+          "target": ""
+        }
+      ],
+      "thresholds": "50,75,100",
+      "title": "Activation success rate",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(237, 129, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": null,
+      "format": "ms",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": true,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "id": 8,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "max(histogram_quantile(0.95, sum(rate(openwhisk_action_duration_seconds_bucket{namespace=~\"$Namespace\",action=~\"$Action\"}[1m])) by (le,action)) * 1e3)",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "refId": "A",
+          "target": ""
+        }
+      ],
+      "thresholds": "1000,2500,5000",
+      "title": "Action duration",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(237, 129, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": null,
+      "format": "ms",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": true,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "id": 26,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "max(histogram_quantile(0.95, sum(rate(openwhisk_action_initTime_seconds_bucket{namespace=~\"$Namespace\",action=~\"$Action\"}[1m])) by (le,action)) * 1e3)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "1000,2500,5000",
+      "title": "Action initialization time",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 14,
+      "title": "Activation result graph",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(increase(openwhisk_action_activations_total{namespace=~\"$Namespace\",action=~\"$Action\"}[1m])) by (action)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{action}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Activations",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "activations",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "id": 18,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(increase(openwhisk_action_status{namespace=~\"$Namespace\",action=~\"$Action\",status=\"success\"}[1m])) by (action)",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{action}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Activation success",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "activations",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "id": 20,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(increase(openwhisk_action_status{namespace=~\"$Namespace\",action=~\"$Action\",status!=\"success\"}[1m])) by (action,status)",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "{{action}}: {{status}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Activation errors",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "activations",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 12,
+      "panels": [],
+      "title": "Duration graph",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 22,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "minSpan": 6,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "repeatDirection": "h",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(openwhisk_action_duration_seconds_bucket{namespace=~\"$Namespace\",action=~\"$Action\"}[1m])) by (le,action)) * 1e3",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{action}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Duration (95th percentile)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "ms",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 10,
+      "panels": [],
+      "title": "Init Time Graph",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 24,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(openwhisk_action_initTime_seconds_bucket{namespace=~\"$Namespace\",action=~\"$Action\"}[1m])) by (le,action)) * 1e3",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{action}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Initialization time (95th percentile)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "text": "All",
+          "value": "All"
+        },
+        "datasource": null,
+        "definition": "label_values(openwhisk_counter_container_activations_total,namespace)",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": false,
+        "name": "Namespace",
+        "options": [],
+        "query": "label_values(openwhisk_action_activations_total,namespace)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": "",
+        "current": {
+          "text": "All",
+          "value": "All"
+        },
+        "datasource": null,
+        "definition": "label_values(openwhisk_counter_container_activations_total,action)",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": false,
+        "name": "Action",
+        "options": [],
+        "query": "label_values(openwhisk_action_activations_total{namespace=~\"$Namespace\"},action)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Openwhisk - Action Performance Metrics",
+  "uid": "Oew1lvymk",
+  "version": 1
+}

--- a/compose/grafana/dashboards/openwhisk_events.json
+++ b/compose/grafana/dashboards/openwhisk_events.json
@@ -119,7 +119,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(sum(increase(openwhisk_action_status{namespace=~\"$Namespace\",action=~\"$Action\",status=\"success\"}[1m])) by (action)) * 100 / sum(sum(increase(openwhisk_action_status{namespace=~\"$Namespace\",action=~\"$Action\"}[1m])) by (action))",
+          "expr": "sum(sum(increase(openwhisk_action_status{namespace=~\"$namespace\",action=~\"$action\",status=\"success\"}[1m])) by (action)) * 100 / sum(sum(increase(openwhisk_action_status{namespace=~\"$namespace\",action=~\"$action\"}[1m])) by (action))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A",
@@ -200,7 +200,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "max(histogram_quantile(0.95, sum(rate(openwhisk_action_duration_seconds_bucket{namespace=~\"$Namespace\",action=~\"$Action\"}[1m])) by (le,action)) * 1e3)",
+          "expr": "max(histogram_quantile(0.95, sum(rate(openwhisk_action_duration_seconds_bucket{namespace=~\"$namespace\",action=~\"$action\"}[1m])) by (le,action)) * 1e3)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -282,7 +282,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "max(histogram_quantile(0.95, sum(rate(openwhisk_action_initTime_seconds_bucket{namespace=~\"$Namespace\",action=~\"$Action\"}[1m])) by (le,action)) * 1e3)",
+          "expr": "max(histogram_quantile(0.95, sum(rate(openwhisk_action_initTime_seconds_bucket{namespace=~\"$namespace\",action=~\"$action\"}[1m])) by (le,action)) * 1e3)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -350,7 +350,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(increase(openwhisk_action_activations_total{namespace=~\"$Namespace\",action=~\"$Action\"}[1m])) by (action)",
+          "expr": "sum(increase(openwhisk_action_activations_total{namespace=~\"$namespace\",action=~\"$action\"}[1m])) by (action)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -436,7 +436,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(increase(openwhisk_action_status{namespace=~\"$Namespace\",action=~\"$Action\",status=\"success\"}[1m])) by (action)",
+          "expr": "sum(increase(openwhisk_action_status{namespace=~\"$namespace\",action=~\"$action\",status=\"success\"}[1m])) by (action)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -523,7 +523,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(increase(openwhisk_action_status{namespace=~\"$Namespace\",action=~\"$Action\",status!=\"success\"}[1m])) by (action,status)",
+          "expr": "sum(increase(openwhisk_action_status{namespace=~\"$namespace\",action=~\"$action\",status!=\"success\"}[1m])) by (action,status)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -629,7 +629,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(openwhisk_action_duration_seconds_bucket{namespace=~\"$Namespace\",action=~\"$Action\"}[1m])) by (le,action)) * 1e3",
+          "expr": "histogram_quantile(0.95, sum(rate(openwhisk_action_duration_seconds_bucket{namespace=~\"$namespace\",action=~\"$action\"}[1m])) by (le,action)) * 1e3",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}}",
@@ -728,7 +728,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(openwhisk_action_initTime_seconds_bucket{namespace=~\"$Namespace\",action=~\"$Action\"}[1m])) by (le,action)) * 1e3",
+          "expr": "histogram_quantile(0.95, sum(rate(openwhisk_action_initTime_seconds_bucket{namespace=~\"$namespace\",action=~\"$action\"}[1m])) by (le,action)) * 1e3",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -792,12 +792,12 @@
           "value": "All"
         },
         "datasource": null,
-        "definition": "label_values(openwhisk_counter_container_activations_total,namespace)",
+        "definition": "label_values(openwhisk_action_activations_total,namespace)",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": false,
-        "name": "Namespace",
+        "name": "namespace",
         "options": [],
         "query": "label_values(openwhisk_action_activations_total,namespace)",
         "refresh": 1,
@@ -822,9 +822,9 @@
         "includeAll": true,
         "label": null,
         "multi": false,
-        "name": "Action",
+        "name": "action",
         "options": [],
-        "query": "label_values(openwhisk_action_activations_total{namespace=~\"$Namespace\"},action)",
+        "query": "label_values(openwhisk_action_activations_total{namespace=~\"$namespace\"},action)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/compose/grafana/dashboards/openwhisk_events.json
+++ b/compose/grafana/dashboards/openwhisk_events.json
@@ -52,7 +52,7 @@
   "editable": true,
   "gnetId": 9564,
   "graphTooltip": 0,
-  "iteration": 1546951304014,
+  "iteration": 1547232303636,
   "links": [],
   "panels": [
     {
@@ -64,7 +64,6 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
       "decimals": 0,
       "description": "Total number of activation in the selected time interval",
       "format": "none",
@@ -146,7 +145,6 @@
         "#508642",
         "#299c46"
       ],
-      "datasource": null,
       "decimals": 0,
       "description": "Total number of successful activations executed",
       "format": "none",
@@ -230,7 +228,6 @@
         "#e24d42",
         "#e24d42"
       ],
-      "datasource": null,
       "decimals": 0,
       "description": "Total number of error activations in the selected time interval",
       "format": "none",
@@ -312,7 +309,6 @@
         "#1f78c1",
         "#1f78c1"
       ],
-      "datasource": null,
       "decimals": 0,
       "description": "Total number of cold starts in the selected time interval",
       "format": "none",
@@ -407,7 +403,6 @@
         "rgba(237, 129, 40, 0.89)",
         "#299c46"
       ],
-      "datasource": null,
       "format": "percent",
       "gauge": {
         "maxValue": 100,
@@ -459,7 +454,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(sum(increase(openwhisk_action_status{namespace=~\"$namespace\",action=~\"$action\",status=\"success\"}[1m])) by (action)) * 100 / sum(sum(increase(openwhisk_action_status{namespace=~\"$namespace\",action=~\"$action\"}[1m])) by (action))",
+          "expr": "sum(increase(openwhisk_action_status{namespace=~\"$namespace\",action=~\"$action\",status=\"success\"}[$interval])) * 100 / sum(increase(openwhisk_action_status{namespace=~\"$namespace\",action=~\"$action\"}[$interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A",
@@ -488,7 +483,6 @@
         "rgba(237, 129, 40, 0.89)",
         "#299c46"
       ],
-      "datasource": null,
       "format": "ms",
       "gauge": {
         "maxValue": 100,
@@ -540,7 +534,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "max(histogram_quantile(0.95, sum(rate(openwhisk_action_duration_seconds_bucket{namespace=~\"$namespace\",action=~\"$action\"}[1m])) by (le,action)) * 1e3)",
+          "expr": "max(histogram_quantile(0.95, sum(rate(openwhisk_action_duration_seconds_bucket{namespace=~\"$namespace\",action=~\"$action\"}[$interval])) by (le,action)) * 1e3)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -570,7 +564,6 @@
         "rgba(237, 129, 40, 0.89)",
         "#299c46"
       ],
-      "datasource": null,
       "format": "ms",
       "gauge": {
         "maxValue": 100,
@@ -622,7 +615,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "max(histogram_quantile(0.95, sum(rate(openwhisk_action_initTime_seconds_bucket{namespace=~\"$namespace\",action=~\"$action\"}[1m])) by (le,action)) * 1e3)",
+          "expr": "max(histogram_quantile(0.95, sum(rate(openwhisk_action_initTime_seconds_bucket{namespace=~\"$namespace\",action=~\"$action\"}[$interval])) by (le,action)) * 1e3)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -658,7 +651,6 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
       "fill": 0,
       "gridPos": {
         "h": 9,
@@ -744,7 +736,6 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -831,7 +822,6 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -930,7 +920,6 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -996,7 +985,7 @@
       },
       "yaxes": [
         {
-          "decimals": null,
+          "decimals": 2,
           "format": "ms",
           "label": "",
           "logBase": 1,
@@ -1036,7 +1025,6 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -1097,6 +1085,7 @@
       },
       "yaxes": [
         {
+          "decimals": 2,
           "format": "ms",
           "label": "",
           "logBase": 1,
@@ -1153,7 +1142,6 @@
       {
         "allValue": "",
         "current": {
-          "tags": [],
           "text": "All",
           "value": "$__all"
         },

--- a/compose/grafana/dashboards/openwhisk_events.json
+++ b/compose/grafana/dashboards/openwhisk_events.json
@@ -1,4 +1,40 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "5.3.2"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": "5.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "5.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": "5.0.0"
+    }
+  ],
   "annotations": {
     "list": [
       {

--- a/compose/grafana/provisioning/dashboards/dashboard.yml
+++ b/compose/grafana/provisioning/dashboards/dashboard.yml
@@ -8,4 +8,4 @@ providers:
   disableDeletion: false
   editable: true
   options:
-    path: /etc/grafana/provisioning/dashboards
+    path: /var/lib/grafana/dashboards

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,11 @@ services:
     volumes:
       - ~/tmp/openwhisk/grafana:/var/lib/grafana
       - ./compose/grafana/provisioning/:/etc/grafana/provisioning/
+      - ./compose/grafana/dashboards/:/var/lib/grafana/dashboards/
+
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=foobar
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
       - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_NAME=Main Org.
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin


### PR DESCRIPTION
This Fixes #8 and will display a grafana dashboard with the OpenWhisk metrics. 
The dashboard is being checked in as most of the changes done in the api must be mirrored in the UI too. 
The authentication step has been disabled as this instance of grafana will only run on developer's machine. 