### PR TITLE
Enable capturing jvm metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,9 @@ dependencies {
     compile ('io.kamon:kamon-prometheus_2.12:1.1.1'){
         exclude group: 'org.nanohttpd'
     }
+    compile ('io.kamon:kamon-system-metrics_2.12:1.0.0') {
+        exclude group: 'io.kamon', module: 'sigar-loader'
+    }
     compile 'io.kamon:kamon-datadog_2.12:1.0.0'
     compile 'io.prometheus:simpleclient:0.6.0'
     compile 'io.prometheus:simpleclient_common:0.6.0'

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -22,9 +22,16 @@ akka.kafka.consumer {
   }
 }
 
-kamon.prometheus {
-  # We expose the metrics endpoint over akka http. So default server is disabled
-  start-embedded-http-server = no
+kamon {
+  prometheus {
+    # We expose the metrics endpoint over akka http. So default server is disabled
+    start-embedded-http-server = no
+  }
+
+  system-metrics {
+    # disable the host metrics as we are only interested in JVM metrics
+    host.enabled = false
+  }
 }
 
 user-events {

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/OpenWhiskEvents.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/OpenWhiskEvents.scala
@@ -20,6 +20,7 @@ import akka.stream.ActorMaterializer
 import com.typesafe.config.Config
 import kamon.Kamon
 import kamon.prometheus.PrometheusReporter
+import kamon.system.SystemMetrics
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.serialization.StringDeserializer
 import pureconfig.loadConfigOrThrow
@@ -35,6 +36,7 @@ object OpenWhiskEvents extends SLF4JLogging {
     Kamon.reconfigure(config)
     val prometheusReporter = new PrometheusReporter()
     Kamon.addReporter(prometheusReporter)
+    SystemMetrics.startCollecting()
 
     val metricConfig = loadConfigOrThrow[MetricConfig](config, "user-events")
 


### PR DESCRIPTION
Enables capturing jvm metrics and exposing them via [Kamon System Metrics][1] module. This would help to understand the GC usage

```
# TYPE jvm_threads gauge
jvm_threads{component="system-metrics",measure="peak"} 31.0
jvm_threads{component="system-metrics",measure="daemon"} 7.0
jvm_threads{component="system-metrics",measure="total"} 31.0
# TYPE jvm_memory_buffer_pool_count gauge
jvm_memory_buffer_pool_count{component="system-metrics",pool="mapped"} 0.0
jvm_memory_buffer_pool_count{component="system-metrics",pool="direct"} 22.0
# TYPE jvm_class_loading gauge
jvm_class_loading{component="system-metrics",mode="loaded"} 6267.0
jvm_class_loading{component="system-metrics",mode="unloaded"} 2.0
jvm_class_loading{component="system-metrics",mode="currently-loaded"} 6265.0
# TYPE jvm_memory_buffer_pool_usage gauge
jvm_memory_buffer_pool_usage{component="system-metrics",pool="direct",measure="capacity"} 1658.0
jvm_memory_buffer_pool_usage{component="system-metrics",pool="direct",measure="used"} 1658.0
jvm_memory_buffer_pool_usage{component="system-metrics",pool="mapped",measure="capacity"} 0.0
jvm_memory_buffer_pool_usage{component="system-metrics",pool="mapped",measure="used"} 0.0
```

[1]: https://github.com/kamon-io/kamon-system-metrics/