### PR TITLE
Start Kamon reporters at startup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,15 +51,15 @@ dependencies {
     compile ('com.github.pureconfig:pureconfig_2.12:0.9.2') {
         exclude group: 'com.github.pureconfig', module: 'pureconfig-macros_2.12'
     }
-    compile 'io.spray:spray-json_2.12:1.3.4'
+    compile 'io.spray:spray-json_2.12:1.3.5'
 
-    compile 'com.typesafe.akka:akka-actor_2.12:2.5.17'
-    compile 'com.typesafe.akka:akka-stream_2.12:2.5.17'
-    compile 'com.typesafe.akka:akka-stream-kafka_2.12:0.22'
-    compile 'com.typesafe.akka:akka-slf4j_2.12:2.5.17'
+    compile "com.typesafe.akka:akka-actor_2.12:${gradle.akka.version}"
+    compile "com.typesafe.akka:akka-stream_2.12:${gradle.akka.version}"
+    compile "com.typesafe.akka:akka-stream-kafka_2.12:0.22"
+    compile "com.typesafe.akka:akka-slf4j_2.12:${gradle.akka.version}"
 
-    compile 'com.typesafe.akka:akka-http-core_2.12:10.1.5'
-    compile 'com.typesafe.akka:akka-http-spray-json_2.12:10.1.5'
+    compile "com.typesafe.akka:akka-http-core_2.12:${gradle.akka_http.version}"
+    compile "com.typesafe.akka:akka-http-spray-json_2.12:${gradle.akka_http.version}"
 
     compile 'ch.qos.logback:logback-classic:1.2.3'
     compile 'org.slf4j:jcl-over-slf4j:1.7.25'
@@ -81,9 +81,9 @@ dependencies {
     testCompile 'junit:junit:4.11'
     testCompile 'org.scalatest:scalatest_2.12:3.0.1'
     testCompile 'net.manub:scalatest-embedded-kafka_2.12:2.0.0'
-    testCompile 'com.typesafe.akka:akka-testkit_2.12:2.5.17'
-    testCompile 'com.typesafe.akka:akka-stream-testkit_2.12:2.5.17'
-    testCompile 'com.typesafe.akka:akka-http-testkit_2.12:10.1.5'
+    testCompile "com.typesafe.akka:akka-testkit_2.12:${gradle.akka.version}"
+    testCompile "com.typesafe.akka:akka-stream-testkit_2.12:${gradle.akka.version}"
+    testCompile "com.typesafe.akka:akka-http-testkit_2.12:${gradle.akka_http.version}"
 
     scoverage 'org.scoverage:scalac-scoverage-plugin_2.12:1.4.0-M4', 'org.scoverage:scalac-scoverage-runtime_2.12:1.4.0-M4'
 

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
 
     compile "com.typesafe.akka:akka-actor_2.12:${gradle.akka.version}"
     compile "com.typesafe.akka:akka-stream_2.12:${gradle.akka.version}"
-    compile "com.typesafe.akka:akka-stream-kafka_2.12:0.22"
+    compile "com.typesafe.akka:akka-stream-kafka_2.12:${gradle.akka_kafka.version}"
     compile "com.typesafe.akka:akka-slf4j_2.12:${gradle.akka.version}"
 
     compile "com.typesafe.akka:akka-http-core_2.12:${gradle.akka_http.version}"
@@ -80,10 +80,10 @@ dependencies {
 
     testCompile 'junit:junit:4.11'
     testCompile 'org.scalatest:scalatest_2.12:3.0.1'
-    testCompile 'net.manub:scalatest-embedded-kafka_2.12:2.0.0'
     testCompile "com.typesafe.akka:akka-testkit_2.12:${gradle.akka.version}"
     testCompile "com.typesafe.akka:akka-stream-testkit_2.12:${gradle.akka.version}"
     testCompile "com.typesafe.akka:akka-http-testkit_2.12:${gradle.akka_http.version}"
+    testCompile "com.typesafe.akka:akka-stream-kafka-testkit_2.12:${gradle.akka_kafka.version}"
 
     scoverage 'org.scoverage:scalac-scoverage-plugin_2.12:1.4.0-M4', 'org.scoverage:scalac-scoverage-runtime_2.12:1.4.0-M4'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,3 +23,4 @@ gradle.ext.scalafmt = [
 
 gradle.ext.akka = [version : '2.5.22']
 gradle.ext.akka_http = [version : '10.1.8']
+gradle.ext.akka_kafka = [version : '1.0.3']

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,10 +13,13 @@ governing permissions and limitations under the License.
 rootProject.name = 'user-metrics'
 
 gradle.ext.scala = [
-    version: '2.12.7',
+    version: '2.12.8',
     compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
 ]
 
 gradle.ext.scalafmt = [
     config: new File(rootProject.projectDir, '.scalafmt.conf')
 ]
+
+gradle.ext.akka = [version : '2.5.22']
+gradle.ext.akka_http = [version : '10.1.8']

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -32,6 +32,12 @@ kamon {
     # disable the host metrics as we are only interested in JVM metrics
     host.enabled = false
   }
+
+  environment {
+    # Identifier for this service. For keeping it backward compatible setting to natch previous
+    # statsd name
+    service = "user-events"
+  }
 }
 
 user-events {

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/EventMessage.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/EventMessage.scala
@@ -148,12 +148,13 @@ object Activation extends DefaultJsonProtocol {
 }
 
 case class Metric(metricName: String, metricValue: Long) extends EventMessageBody {
-  val typeName = "Metric"
+  val typeName = Metric.typeName
   def serialize = toJson.compactPrint
   def toJson = Metric.metricFormat.write(this).asJsObject
 }
 
 object Metric extends DefaultJsonProtocol {
+  val typeName = "Metric"
   def parse(msg: String) = Try(metricFormat.read(msg.parseJson))
   implicit val metricFormat = jsonFormat(Metric.apply _, "metricName", "metricValue")
 }

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/Main.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/Main.scala
@@ -14,12 +14,14 @@ package com.adobe.api.platform.runtime.metrics
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
-import scala.concurrent.duration.DurationInt
+import kamon.Kamon
 
+import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, ExecutionContextExecutor, Future}
 
 object Main {
   def main(args: Array[String]): Unit = {
+    Kamon.loadReportersFromConfig()
     implicit val system: ActorSystem = ActorSystem("events-actor-system")
     implicit val materializer: ActorMaterializer = ActorMaterializer()
     val binding = OpenWhiskEvents.start(system.settings.config)

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/OpenWhiskEventsTests.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/OpenWhiskEventsTests.scala
@@ -16,11 +16,10 @@ import akka.http.scaladsl.model.{HttpRequest, StatusCodes}
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import com.typesafe.config.ConfigFactory
 import kamon.Kamon
-import net.manub.embeddedkafka.EmbeddedKafkaConfig
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import scala.concurrent.duration._
 
+import scala.concurrent.duration._
 import scala.util.Try
 
 @RunWith(classOf[JUnitRunner])
@@ -28,12 +27,9 @@ class OpenWhiskEventsTests extends KafkaSpecBase {
   behavior of "Server"
 
   it should "start working http server" in {
-    val kconfig = EmbeddedKafkaConfig(kafkaPort = 0, zooKeeperPort = 0)
-    withRunningKafkaOnFoundPort(kconfig) { implicit actualConfig =>
-      val kafkaPort = actualConfig.kafkaPort
-      val httpPort = freePort()
-      val globalConfig = system.settings.config
-      val config = ConfigFactory.parseString(s"""
+    val httpPort = freePort()
+    val globalConfig = system.settings.config
+    val config = ConfigFactory.parseString(s"""
            | akka.kafka.consumer.kafka-clients {
            |  bootstrap.servers = "localhost:$kafkaPort"
            | }
@@ -48,18 +44,17 @@ class OpenWhiskEventsTests extends KafkaSpecBase {
            | }
          """.stripMargin).withFallback(globalConfig)
 
-      val binding = OpenWhiskEvents.start(config).futureValue
-      val res = get("localhost", httpPort, "/ping")
-      res shouldBe Some(StatusCodes.OK, "pong")
+    val binding = OpenWhiskEvents.start(config).futureValue
+    val res = get("localhost", httpPort, "/ping")
+    res shouldBe Some(StatusCodes.OK, "pong")
 
-      //Check if metrics using Kamon API gets included in consolidated Prometheus
-      Kamon.counter("fooTest").increment(42)
-      sleep(1.second)
-      val metricRes = get("localhost", httpPort, "/metrics")
-      metricRes.get._2 should include("fooTest")
+    //Check if metrics using Kamon API gets included in consolidated Prometheus
+    Kamon.counter("fooTest").increment(42)
+    sleep(1.second)
+    val metricRes = get("localhost", httpPort, "/metrics")
+    metricRes.get._2 should include("fooTest")
 
-      binding.unbind().futureValue
-    }
+    binding.unbind().futureValue
   }
 
   def get(host: String, port: Int, path: String = "/") = {


### PR DESCRIPTION
Currently we have configured Kamon but not enabled it to run on startup. There are two aspects in which Kamon is used 

1. User Metric - Sending the user metric to Kamon reporters. By default this is disabled as we intend to send such high cardinality metrics to Prometheus only.
2. System Metrics - Like jvm stats, rate of event processed etc. These can be sent to Kamon reporters such that user-metric health/performance itself can be monitored 

This PR enables that by allow Kamon to load reporters from config. By default we have no reporter configured. However in our deployments we can extend the config and add new reporters etc