### PR TITLE
Record Global metrics

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -32,6 +32,12 @@ kamon {
     # disable the host metrics as we are only interested in JVM metrics
     host.enabled = false
   }
+
+  environment {
+    # Identifier for this service. For keeping it backward compatible setting to natch previous
+    # statsd name
+    service = "user-events"
+  }
 }
 
 user-events {

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/EventConsumer.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/EventConsumer.scala
@@ -38,6 +38,7 @@ case class EventConsumer(settings: ConsumerSettings[String, String], recorders: 
   private val metricCounter = Kamon.counter("openwhisk.userevents.global.metric")
 
   private val statusCounter = Kamon.counter("openwhisk.userevents.global.status")
+  private val coldStartCounter = Kamon.counter("openwhisk.userevents.global.coldStarts")
 
   private val statusSuccess = statusCounter.refine("status" -> Activation.statusSuccess)
   private val statusFailure = statusCounter.refine("status" -> "failure")
@@ -92,6 +93,7 @@ case class EventConsumer(settings: ConsumerSettings[String, String], recorders: 
     }
 
     if (a.status != Activation.statusSuccess) statusFailure.increment()
+    if (a.isColdStart) coldStartCounter.increment()
   }
 }
 

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/EventMessage.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/EventMessage.scala
@@ -148,12 +148,13 @@ object Activation extends DefaultJsonProtocol {
 }
 
 case class Metric(metricName: String, metricValue: Long) extends EventMessageBody {
-  val typeName = "Metric"
+  val typeName = Metric.typeName
   def serialize = toJson.compactPrint
   def toJson = Metric.metricFormat.write(this).asJsObject
 }
 
 object Metric extends DefaultJsonProtocol {
+  val typeName = "Metric"
   def parse(msg: String) = Try(metricFormat.read(msg.parseJson))
   implicit val metricFormat = jsonFormat(Metric.apply _, "metricName", "metricValue")
 }

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/EventMessage.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/EventMessage.scala
@@ -113,6 +113,8 @@ case class Activation(name: String,
     case 3 => statusInternalError
     case x => x.toString
   }
+
+  def isColdStart: Boolean = initTime > 0
 }
 
 object Activation extends DefaultJsonProtocol {

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonRecorder.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonRecorder.scala
@@ -58,7 +58,7 @@ object KamonRecorder extends MetricRecorder with KamonMetricNames {
     def record(a: Activation): Unit = {
       activations.increment()
 
-      if (a.initTime > 0) {
+      if (a.isColdStart) {
         coldStarts.increment()
         initTime.record(a.initTime)
       }

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/Main.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/Main.scala
@@ -14,12 +14,14 @@ package com.adobe.api.platform.runtime.metrics
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
-import scala.concurrent.duration.DurationInt
+import kamon.Kamon
 
+import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, ExecutionContextExecutor, Future}
 
 object Main {
   def main(args: Array[String]): Unit = {
+    Kamon.loadReportersFromConfig()
     implicit val system: ActorSystem = ActorSystem("events-actor-system")
     implicit val materializer: ActorMaterializer = ActorMaterializer()
     val binding = OpenWhiskEvents.start(system.settings.config)

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorder.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorder.scala
@@ -77,7 +77,7 @@ case class PrometheusRecorder(kamon: PrometheusReporter) extends MetricRecorder 
 
       activations.inc()
 
-      if (a.initTime > 0) {
+      if (a.isColdStart) {
         coldStarts.inc()
         initTime.observe(seconds(a.initTime))
       }


### PR DESCRIPTION
Currently we record metrics at namespace and action level for each activation and these are sent to Prometheus (optionally to Kamon). For some setups we may wish to record global metrics (without namespace and action dimension) globally and send it to collection agent like Datadog in addition to Prometheus. 

Note that for Prometheus global metrics can be computed currently also by dropping the dimensions in query

In general there are 2 types of metrics

1. User Metric - Sending the user metric to Kamon reporters. By default this is disabled as we intend to send such high cardinality metrics to Prometheus only.
2. System Metrics - Like jvm stats, rate of event processed etc. These can be sent to Kamon reporters such that user-metric health/performance itself can be monitored 

This PR enables support for such cases by recording global metrics via Kamon and have them enabled always



By default we have no reporter configured. However in our deployments we can extend the config and add new reporters etc