### PR TITLE
Track user event consumer Kafka lag as metric

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -23,6 +23,9 @@ akka.kafka.consumer {
 }
 
 kamon {
+  metric {
+    tick-interval = 15 seconds
+  }
   prometheus {
     # We expose the metrics endpoint over akka http. So default server is disabled
     start-embedded-http-server = no


### PR DESCRIPTION
Tracks the Kafka Consumer lag via jmx read and exposes that as a gauge. This would help us to see if user-event service is getting overloaded with load or not