### PR TITLE
Add initiator namespace tag for all metrics

### DIFF
--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/EventConsumer.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/EventConsumer.scala
@@ -31,7 +31,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 
 trait MetricRecorder {
-  def processEvent(activation: Activation): Unit
+  def processEvent(activation: Activation, initiatorNamespace: String): Unit
 }
 
 case class EventConsumer(settings: ConsumerSettings[String, String], recorders: Seq[MetricRecorder])(
@@ -96,7 +96,7 @@ case class EventConsumer(settings: ConsumerSettings[String, String], recorders: 
       .collect { case e if e.eventType == Activation.typeName => e } //Look for only Activations
       .foreach { e =>
         val a = e.body.asInstanceOf[Activation]
-        recorders.foreach(_.processEvent(a))
+        recorders.foreach(_.processEvent(a, e.namespace))
         updateGlobalMetrics(a)
       }
   }

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonRecorder.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonRecorder.scala
@@ -46,7 +46,12 @@ object KamonRecorder extends MetricRecorder with KamonMetricNames {
 
   case class KamonMetrics(namespace: String, action: String, kind: String, memory: String, initiator: String) {
     private val activationTags =
-      Map(`actionNamespace` -> namespace, `initiatorNamespace` -> initiator, `actionName` -> action, `kind` -> kind, `memory` -> memory)
+      Map(
+        `actionNamespace` -> namespace,
+        `initiatorNamespace` -> initiator,
+        `actionName` -> action,
+        `kind` -> kind,
+        `memory` -> memory)
     private val tags = Map(`actionNamespace` -> namespace, `initiatorNamespace` -> initiator, `actionName` -> action)
 
     private val activations = Kamon.counter(activationMetric).refine(activationTags)

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonRecorder.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonRecorder.scala
@@ -30,24 +30,24 @@ trait KamonMetricNames extends MetricNames {
 object KamonRecorder extends MetricRecorder with KamonMetricNames {
   private val metrics = new TrieMap[String, KamonMetrics]
 
-  def processEvent(activation: Activation): Unit = {
-    lookup(activation).record(activation)
+  def processEvent(activation: Activation, initiatorNamespace: String): Unit = {
+    lookup(activation, initiatorNamespace).record(activation)
   }
 
-  def lookup(activation: Activation): KamonMetrics = {
+  def lookup(activation: Activation, initiatorNamespace: String): KamonMetrics = {
     val name = activation.name
     val kind = activation.kind
     val memory = activation.memory.toString
     metrics.getOrElseUpdate(name, {
       val (namespace, action) = getNamespaceAndActionName(name)
-      KamonMetrics(namespace, action, kind, memory)
+      KamonMetrics(namespace, action, kind, memory, initiatorNamespace)
     })
   }
 
-  case class KamonMetrics(namespace: String, action: String, kind: String, memory: String) {
+  case class KamonMetrics(namespace: String, action: String, kind: String, memory: String, initiator: String) {
     private val activationTags =
-      Map(`actionNamespace` -> namespace, `actionName` -> action, `kind` -> kind, `memory` -> memory)
-    private val tags = Map(`actionNamespace` -> namespace, `actionName` -> action)
+      Map(`actionNamespace` -> namespace, `initiatorNamespace` -> initiator, `actionName` -> action, `kind` -> kind, `memory` -> memory)
+    private val tags = Map(`actionNamespace` -> namespace, `initiatorNamespace` -> initiator, `actionName` -> action)
 
     private val activations = Kamon.counter(activationMetric).refine(activationTags)
     private val coldStarts = Kamon.counter(coldStartMetric).refine(tags)

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/MetricNames.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/MetricNames.scala
@@ -14,6 +14,7 @@ package com.adobe.api.platform.runtime.metrics
 
 trait MetricNames {
   val actionNamespace = "namespace"
+  val initiatorNamespace = "initiator"
   val actionName = "action"
   val actionStatus = "status"
   val actionMemory = "memory"

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorder.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorder.scala
@@ -58,7 +58,11 @@ case class PrometheusRecorder(kamon: PrometheusReporter) extends MetricRecorder 
     })
   }
 
-  case class PrometheusMetrics(namespace: String, action: String, kind: String, memory: String, initiatorNamespace: String) {
+  case class PrometheusMetrics(namespace: String,
+                               action: String,
+                               kind: String,
+                               memory: String,
+                               initiatorNamespace: String) {
     private val activations = activationCounter.labels(namespace, initiatorNamespace, action, kind, memory)
     private val coldStarts = coldStartCounter.labels(namespace, initiatorNamespace, action)
     private val waitTime = waitTimeHisto.labels(namespace, initiatorNamespace, action)
@@ -68,9 +72,12 @@ case class PrometheusRecorder(kamon: PrometheusReporter) extends MetricRecorder 
     private val gauge = memoryGauge.labels(namespace, initiatorNamespace, action)
 
     private val statusSuccess = statusCounter.labels(namespace, initiatorNamespace, action, Activation.statusSuccess)
-    private val statusApplicationError = statusCounter.labels(namespace, initiatorNamespace, action, Activation.statusApplicationError)
-    private val statusDeveloperError = statusCounter.labels(namespace, initiatorNamespace, action, Activation.statusDeveloperError)
-    private val statusInternalError = statusCounter.labels(namespace, initiatorNamespace, action, Activation.statusInternalError)
+    private val statusApplicationError =
+      statusCounter.labels(namespace, initiatorNamespace, action, Activation.statusApplicationError)
+    private val statusDeveloperError =
+      statusCounter.labels(namespace, initiatorNamespace, action, Activation.statusDeveloperError)
+    private val statusInternalError =
+      statusCounter.labels(namespace, initiatorNamespace, action, Activation.statusInternalError)
 
     def record(a: Activation): Unit = {
       gauge.observe(a.memory)
@@ -129,17 +136,47 @@ case class PrometheusRecorder(kamon: PrometheusReporter) extends MetricRecorder 
 
 object PrometheusRecorder extends PrometheusMetricNames {
   private val activationCounter =
-    counter(activationMetric, "Activation Count", actionNamespace, initiatorNamespace, actionName, actionKind, actionMemory)
-  private val coldStartCounter = counter(coldStartMetric, "Cold start counts", actionNamespace, initiatorNamespace, actionName)
+    counter(
+      activationMetric,
+      "Activation Count",
+      actionNamespace,
+      initiatorNamespace,
+      actionName,
+      actionKind,
+      actionMemory)
+  private val coldStartCounter =
+    counter(coldStartMetric, "Cold start counts", actionNamespace, initiatorNamespace, actionName)
   private val statusCounter =
-    counter(statusMetric, "Activation failure status type", actionNamespace, initiatorNamespace, actionName, actionStatus)
-  private val waitTimeHisto = histogram(waitTimeMetric, "Internal system hold time", actionNamespace, initiatorNamespace, actionName)
+    counter(
+      statusMetric,
+      "Activation failure status type",
+      actionNamespace,
+      initiatorNamespace,
+      actionName,
+      actionStatus)
+  private val waitTimeHisto =
+    histogram(waitTimeMetric, "Internal system hold time", actionNamespace, initiatorNamespace, actionName)
   private val initTimeHisto =
-    histogram(initTimeMetric, "Time it took to initialize an action, e.g. docker init", actionNamespace, initiatorNamespace, actionName)
+    histogram(
+      initTimeMetric,
+      "Time it took to initialize an action, e.g. docker init",
+      actionNamespace,
+      initiatorNamespace,
+      actionName)
   private val durationHisto =
-    histogram(durationMetric, "Actual time the action code was running", actionNamespace, initiatorNamespace, actionName)
+    histogram(
+      durationMetric,
+      "Actual time the action code was running",
+      actionNamespace,
+      initiatorNamespace,
+      actionName)
   private val memoryGauge =
-    histogram(memoryMetric, "Memory consumption of the action containers", actionNamespace, initiatorNamespace, actionName)
+    histogram(
+      memoryMetric,
+      "Memory consumption of the action containers",
+      actionNamespace,
+      initiatorNamespace,
+      actionName)
 
   private def counter(name: String, help: String, tags: String*) =
     Counter

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorder.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorder.scala
@@ -40,37 +40,37 @@ case class PrometheusRecorder(kamon: PrometheusReporter) extends MetricRecorder 
   import PrometheusRecorder._
   private val metrics = new TrieMap[String, PrometheusMetrics]
 
-  def processEvent(activation: Activation): Unit = {
-    lookup(activation).record(activation)
+  def processEvent(activation: Activation, initiatorNamespace: String): Unit = {
+    lookup(activation, initiatorNamespace).record(activation)
   }
 
   override def getReport(): MessageEntity =
     HttpEntity(PrometheusExporter.textV4, createSource())
 
-  private def lookup(activation: Activation): PrometheusMetrics = {
+  private def lookup(activation: Activation, initiatorNamespace: String): PrometheusMetrics = {
     //TODO Unregister unused actions
     val name = activation.name
     val kind = activation.kind
     val memory = activation.memory.toString
     metrics.getOrElseUpdate(name, {
       val (namespace, action) = getNamespaceAndActionName(name)
-      PrometheusMetrics(namespace, action, kind, memory)
+      PrometheusMetrics(namespace, action, kind, memory, initiatorNamespace)
     })
   }
 
-  case class PrometheusMetrics(namespace: String, action: String, kind: String, memory: String) {
-    private val activations = activationCounter.labels(namespace, action, kind, memory)
-    private val coldStarts = coldStartCounter.labels(namespace, action)
-    private val waitTime = waitTimeHisto.labels(namespace, action)
-    private val initTime = initTimeHisto.labels(namespace, action)
-    private val duration = durationHisto.labels(namespace, action)
+  case class PrometheusMetrics(namespace: String, action: String, kind: String, memory: String, initiatorNamespace: String) {
+    private val activations = activationCounter.labels(namespace, initiatorNamespace, action, kind, memory)
+    private val coldStarts = coldStartCounter.labels(namespace, initiatorNamespace, action)
+    private val waitTime = waitTimeHisto.labels(namespace, initiatorNamespace, action)
+    private val initTime = initTimeHisto.labels(namespace, initiatorNamespace, action)
+    private val duration = durationHisto.labels(namespace, initiatorNamespace, action)
 
-    private val gauge = memoryGauge.labels(namespace, action)
+    private val gauge = memoryGauge.labels(namespace, initiatorNamespace, action)
 
-    private val statusSuccess = statusCounter.labels(namespace, action, Activation.statusSuccess)
-    private val statusApplicationError = statusCounter.labels(namespace, action, Activation.statusApplicationError)
-    private val statusDeveloperError = statusCounter.labels(namespace, action, Activation.statusDeveloperError)
-    private val statusInternalError = statusCounter.labels(namespace, action, Activation.statusInternalError)
+    private val statusSuccess = statusCounter.labels(namespace, initiatorNamespace, action, Activation.statusSuccess)
+    private val statusApplicationError = statusCounter.labels(namespace, initiatorNamespace, action, Activation.statusApplicationError)
+    private val statusDeveloperError = statusCounter.labels(namespace, initiatorNamespace, action, Activation.statusDeveloperError)
+    private val statusInternalError = statusCounter.labels(namespace, initiatorNamespace, action, Activation.statusInternalError)
 
     def record(a: Activation): Unit = {
       gauge.observe(a.memory)
@@ -91,7 +91,7 @@ case class PrometheusRecorder(kamon: PrometheusReporter) extends MetricRecorder 
         case Activation.statusApplicationError => statusApplicationError.inc()
         case Activation.statusDeveloperError   => statusDeveloperError.inc()
         case Activation.statusInternalError    => statusInternalError.inc()
-        case x                                 => statusCounter.labels(namespace, action, x).inc()
+        case x                                 => statusCounter.labels(namespace, initiatorNamespace, action, x).inc()
       }
     }
   }
@@ -129,17 +129,17 @@ case class PrometheusRecorder(kamon: PrometheusReporter) extends MetricRecorder 
 
 object PrometheusRecorder extends PrometheusMetricNames {
   private val activationCounter =
-    counter(activationMetric, "Activation Count", actionNamespace, actionName, actionKind, actionMemory)
-  private val coldStartCounter = counter(coldStartMetric, "Cold start counts", actionNamespace, actionName)
+    counter(activationMetric, "Activation Count", actionNamespace, initiatorNamespace, actionName, actionKind, actionMemory)
+  private val coldStartCounter = counter(coldStartMetric, "Cold start counts", actionNamespace, initiatorNamespace, actionName)
   private val statusCounter =
-    counter(statusMetric, "Activation failure status type", actionNamespace, actionName, actionStatus)
-  private val waitTimeHisto = histogram(waitTimeMetric, "Internal system hold time", actionNamespace, actionName)
+    counter(statusMetric, "Activation failure status type", actionNamespace, initiatorNamespace, actionName, actionStatus)
+  private val waitTimeHisto = histogram(waitTimeMetric, "Internal system hold time", actionNamespace, initiatorNamespace, actionName)
   private val initTimeHisto =
-    histogram(initTimeMetric, "Time it took to initialize an action, e.g. docker init", actionNamespace, actionName)
+    histogram(initTimeMetric, "Time it took to initialize an action, e.g. docker init", actionNamespace, initiatorNamespace, actionName)
   private val durationHisto =
-    histogram(durationMetric, "Actual time the action code was running", actionNamespace, actionName)
+    histogram(durationMetric, "Actual time the action code was running", actionNamespace, initiatorNamespace, actionName)
   private val memoryGauge =
-    histogram(memoryMetric, "Memory consumption of the action containers", actionNamespace, actionName)
+    histogram(memoryMetric, "Memory consumption of the action containers", actionNamespace, initiatorNamespace, actionName)
 
   private def counter(name: String, help: String, tags: String*) =
     Counter

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/KamonRecorderTests.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/KamonRecorderTests.scala
@@ -65,18 +65,10 @@ class KamonRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with Kamo
       consumer.shutdown().futureValue
       sleep(1.second, "sleeping for Kamon reporters to get invoked")
       TestReporter.counter(activationMetric).get.value shouldBe 1
-      TestReporter
-        .counter(activationMetric)
-        .get
-        .tags
-        .find(_._2 == "whisk.system")
-        .size shouldBe 1
-      TestReporter
-        .counter(activationMetric)
-        .get
-        .tags
-        .find(_._2 == "apimgmt/createApi")
-        .size shouldBe 1
+      TestReporter.counter(activationMetric).get.tags("namespace") shouldBe "whisk.system"
+      TestReporter.counter(activationMetric).get.tags("initiator") shouldBe "testNS"
+      TestReporter.counter(activationMetric).get.tags("action") shouldBe "apimgmt/createApi"
+
       TestReporter.counter(statusMetric).get.tags.find(_._2 == Activation.statusDeveloperError).size shouldBe 1
       TestReporter.counter(coldStartMetric).get.value shouldBe 1
       TestReporter.counter(statusMetric).get.value shouldBe 1
@@ -84,27 +76,18 @@ class KamonRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with Kamo
       TestReporter.histogram(waitTimeMetric).get.distribution.count shouldBe 1
       TestReporter.histogram(initTimeMetric).get.distribution.count shouldBe 1
       TestReporter.histogram(durationMetric).get.distribution.count shouldBe 1
-      TestReporter
-        .histogram(durationMetric)
-        .get
-        .tags
-        .find(_._2 == "whisk.system")
-        .size shouldBe 1
-      TestReporter
-        .histogram(durationMetric)
-        .get
-        .tags
-        .find(_._2 == "apimgmt/createApi")
-        .size shouldBe 1
+      TestReporter.histogram(durationMetric).get.tags("namespace") shouldBe "whisk.system"
+      TestReporter.histogram(durationMetric).get.tags("initiator") shouldBe "testNS"
+      TestReporter.histogram(durationMetric).get.tags("action") shouldBe "apimgmt/createApi"
     }
   }
 
-  private def newActivationEvent(name: String, kind: String = "nodejs:6") =
+  private def newActivationEvent(name: String, kind: String = "nodejs:6", initiator: String = "testNS") =
     EventMessage(
       "test",
       Activation(name, 2, 3, 5, 11, kind, false, 256, None),
       "testuser",
-      "testNS",
+      initiator,
       "test",
       Activation.typeName)
 

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorderTests.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorderTests.scala
@@ -71,7 +71,10 @@ class PrometheusRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with
       Array(namespace, initiator, action))
 
   private def counter(name: String) =
-    CollectorRegistry.defaultRegistry.getSampleValue(name, Array("namespace", "initiator", "action"), Array(namespace, initiator, action))
+    CollectorRegistry.defaultRegistry.getSampleValue(
+      name,
+      Array("namespace", "initiator", "action"),
+      Array(namespace, initiator, action))
 
   private def counterTotal(name: String) =
     CollectorRegistry.defaultRegistry.getSampleValue(

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorderTests.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorderTests.scala
@@ -26,6 +26,7 @@ class PrometheusRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with
 
   behavior of "PrometheusConsumer"
   val namespace = "whisk.system"
+  val initiator = "testNS"
   val action = "apimgmt/createApi"
   val kind = "nodejs:10"
   val memory = "256"
@@ -38,7 +39,7 @@ class PrometheusRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with
       val consumer = createConsumer(actualConfig.kafkaPort, system.settings.config)
       publishStringMessageToKafka(
         EventConsumer.userEventTopic,
-        newActivationEvent(s"$namespace/$action", kind, memory).serialize)
+        newActivationEvent(s"$namespace/$action", kind, memory, initiator).serialize)
 
       sleep(sleepAfterProduce, "sleeping post produce")
       consumer.shutdown().futureValue
@@ -54,40 +55,40 @@ class PrometheusRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with
     }
   }
 
-  private def newActivationEvent(name: String, kind: String, memory: String) =
+  private def newActivationEvent(name: String, kind: String, memory: String, initiator: String) =
     EventMessage(
       "test",
       Activation(name, 2, 3, 5, 11, kind, false, memory.toInt, None),
-      "testuser",
-      "testNS",
+      "userId",
+      initiator,
       "test",
       Activation.typeName)
 
   private def gauge(name: String) =
     CollectorRegistry.defaultRegistry.getSampleValue(
       s"${name}_count",
-      Array("namespace", "action"),
-      Array(namespace, action))
+      Array("namespace", "initiator", "action"),
+      Array(namespace, initiator, action))
 
   private def counter(name: String) =
-    CollectorRegistry.defaultRegistry.getSampleValue(name, Array("namespace", "action"), Array(namespace, action))
+    CollectorRegistry.defaultRegistry.getSampleValue(name, Array("namespace", "initiator", "action"), Array(namespace, initiator, action))
 
   private def counterTotal(name: String) =
     CollectorRegistry.defaultRegistry.getSampleValue(
       name,
-      Array("namespace", "action", "kind", "memory"),
-      Array(namespace, action, kind, memory))
+      Array("namespace", "initiator", "action", "kind", "memory"),
+      Array(namespace, initiator, action, kind, memory))
 
   private def counterStatus(name: String, status: String) =
     CollectorRegistry.defaultRegistry.getSampleValue(
       name,
-      Array("namespace", "action", "status"),
-      Array(namespace, action, status))
+      Array("namespace", "initiator", "action", "status"),
+      Array(namespace, initiator, action, status))
 
   private def histogramCount(name: String) =
     CollectorRegistry.defaultRegistry.getSampleValue(
       s"${name}_count",
-      Array("namespace", "action"),
-      Array(namespace, action))
+      Array("namespace", "initiator", "action"),
+      Array(namespace, initiator, action))
 
 }


### PR DESCRIPTION
Fixes #24. 
It adds a new tag to all existing metrics. This tag is called `initiator` and contains the value of the namespace that has initiated the activation. 