### PR TITLE
Bugfix: Labels names the same as values

### DIFF
--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonRecorder.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonRecorder.scala
@@ -46,7 +46,7 @@ object KamonRecorder extends MetricRecorder with KamonMetricNames {
 
   case class KamonMetrics(namespace: String, action: String, kind: String, memory: String) {
     private val activationTags =
-      Map(`actionNamespace` -> namespace, `actionName` -> action, `kind` -> kind, `memory` -> memory)
+      Map(`actionNamespace` -> namespace, `actionName` -> action, `actionKind` -> kind, `actionMemory` -> memory)
     private val tags = Map(`actionNamespace` -> namespace, `actionName` -> action)
 
     private val activations = Kamon.counter(activationMetric).refine(activationTags)

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/KamonRecorderTests.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/KamonRecorderTests.scala
@@ -68,6 +68,15 @@ class KamonRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with Kamo
       TestReporter
         .counter(activationMetric)
         .get
+        .tags("kind") shouldBe "nodejs:6"
+      TestReporter
+        .counter(activationMetric)
+        .get
+        .tags("memory") shouldBe "256"
+
+      TestReporter
+        .counter(activationMetric)
+        .get
         .tags
         .find(_._2 == "whisk.system")
         .size shouldBe 1


### PR DESCRIPTION
Fix issue of label names being incorrectly defined. 
Before fix: 
```
{nodejs:6="nodejs:6", 256="256"}
```
after fix: 
```
{kind="nodejs:6", memory="256"}
```
