### PR TITLE
Uses Duration type for time units in Activation

### DIFF
--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/EventConsumer.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/EventConsumer.scala
@@ -113,11 +113,11 @@ case class EventConsumer(settings: ConsumerSettings[String, String], recorders: 
     if (a.status != Activation.statusSuccess) statusFailure.increment()
     if (a.isColdStart) {
       coldStartCounter.increment()
-      initTime.record(a.initTime)
+      initTime.record(a.initTime.toMillis)
     }
 
-    waitTime.record(a.waitTime)
-    duration.record(a.duration)
+    waitTime.record(a.waitTime.toMillis)
+    duration.record(a.duration.toMillis)
   }
 
   private def updatedSettings = settings.withProperty(ConsumerConfig.CLIENT_ID_CONFIG, id)

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonRecorder.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonRecorder.scala
@@ -60,12 +60,12 @@ object KamonRecorder extends MetricRecorder with KamonMetricNames {
 
       if (a.isColdStart) {
         coldStarts.increment()
-        initTime.record(a.initTime)
+        initTime.record(a.initTime.toMillis)
       }
 
       //waitTime may be zero for activations which are part of sequence
-      waitTime.record(a.waitTime)
-      duration.record(a.duration)
+      waitTime.record(a.waitTime.toMillis)
+      duration.record(a.duration.toMillis)
 
       Kamon.counter(statusMetric).refine(tags + ("status" -> a.status)).increment()
     }

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorder.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorder.scala
@@ -25,6 +25,7 @@ import kamon.prometheus.PrometheusReporter
 
 import scala.collection.JavaConverters._
 import scala.collection.concurrent.TrieMap
+import scala.concurrent.duration.Duration
 
 trait PrometheusMetricNames extends MetricNames {
   val activationMetric = "openwhisk_action_activations_total"
@@ -96,7 +97,8 @@ case class PrometheusRecorder(kamon: PrometheusReporter) extends MetricRecorder 
     }
   }
 
-  private def seconds(timeInMillis: Long) = TimeUnit.MILLISECONDS.toSeconds(timeInMillis)
+  //Returns a floating point number
+  private def seconds(time: Duration): Double = time.toUnit(TimeUnit.SECONDS)
 
   private def createSource() =
     Source.combine(createJavaClientSource(), createKamonSource())(Concat(_)).map(ByteString(_))

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/ActivationsTest.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/ActivationsTest.scala
@@ -1,0 +1,64 @@
+/*
+Copyright 2018 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+ */
+
+package com.adobe.api.platform.runtime.metrics
+
+import org.junit.runner.RunWith
+import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.junit.JUnitRunner
+
+import scala.concurrent.duration._
+
+@RunWith(classOf[JUnitRunner])
+class ActivationsTest extends FlatSpec with Matchers {
+  behavior of "Activation"
+
+  it should "deserialize normal values" in {
+    val json = """{
+                 |  "body": {
+                 |    "statusCode": 0,
+                 |    "duration": 3,
+                 |    "name": "whisk.system/invokerHealthTestAction0",
+                 |    "waitTime": 583915671,
+                 |    "conductor": false,
+                 |    "kind": "nodejs:6",
+                 |    "initTime": 0,
+                 |    "memory": 256
+                 |  },
+                 |  "eventType": "Activation",
+                 |  "source": "invoker0",
+                 |  "subject": "demo",
+                 |  "timestamp": 1524476122676,
+                 |  "userId": "d0888ad5-5a92-435e-888a-d55a92935e54",
+                 |  "namespace": "demo"
+                 |}""".stripMargin
+    val a = EventMessage.parse(json).get.body.asInstanceOf[Activation]
+    a.duration shouldBe 3.millis
+    a.initTime shouldBe Duration.Zero
+    a.waitTime shouldBe 583915671.millis
+  }
+
+  it should "deserialize with negative durations" in {
+    val json = """{
+                 |    "statusCode": 0,
+                 |    "duration": 3,
+                 |    "name": "whisk.system/invokerHealthTestAction0",
+                 |    "waitTime": -50,
+                 |    "conductor": false,
+                 |    "kind": "nodejs:6",
+                 |    "initTime": 0,
+                 |    "memory": 256
+                 |}""".stripMargin
+    val a = Activation.parse(json).get
+    a.waitTime shouldBe Duration.Zero
+  }
+}

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/KamonRecorderTests.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/KamonRecorderTests.scala
@@ -111,7 +111,7 @@ class KamonRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with Kamo
   private def newActivationEvent(name: String, kind: String = "nodejs:6") =
     EventMessage(
       "test",
-      Activation(name, 2, 3, 5, 11, kind, false, 256, None),
+      Activation(name, 2, 3.millis, 5.millis, 11.millis, kind, false, 256, None),
       "testuser",
       "testNS",
       "test",

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorderTests.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorderTests.scala
@@ -47,8 +47,13 @@ class PrometheusRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with
       counterStatus(statusMetric, Activation.statusDeveloperError) shouldBe 1
 
       histogramCount(waitTimeMetric) shouldBe 1
+      histogramSum(waitTimeMetric) shouldBe (0.03 +- 0.001)
+
       histogramCount(initTimeMetric) shouldBe 1
+      histogramSum(initTimeMetric) shouldBe (433.433 +- 0.01)
+
       histogramCount(durationMetric) shouldBe 1
+      histogramSum(durationMetric) shouldBe (1.254 +- 0.01)
 
       gauge(memoryMetric) shouldBe 1
     }
@@ -57,7 +62,7 @@ class PrometheusRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with
   private def newActivationEvent(name: String, kind: String, memory: String) =
     EventMessage(
       "test",
-      Activation(name, 2, 3.millis, 5.millis, 11.millis, kind, false, memory.toInt, None),
+      Activation(name, 2, 1254.millis, 30.millis, 433433.millis, kind, false, memory.toInt, None),
       "testuser",
       "testNS",
       "test",
@@ -90,4 +95,8 @@ class PrometheusRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with
       Array("namespace", "action"),
       Array(namespace, action))
 
+  private def histogramSum(name: String) =
+    CollectorRegistry.defaultRegistry
+      .getSampleValue(s"${name}_sum", Array("namespace", "action"), Array(namespace, action))
+      .doubleValue()
 }

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorderTests.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorderTests.scala
@@ -57,7 +57,7 @@ class PrometheusRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with
   private def newActivationEvent(name: String, kind: String, memory: String) =
     EventMessage(
       "test",
-      Activation(name, 2, 3, 5, 11, kind, false, memory.toInt, None),
+      Activation(name, 2, 3.millis, 5.millis, 11.millis, kind, false, memory.toInt, None),
       "testuser",
       "testNS",
       "test",

--- a/src/test/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorderTests.scala
+++ b/src/test/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorderTests.scala
@@ -101,6 +101,6 @@ class PrometheusRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with
 
   private def histogramSum(name: String) =
     CollectorRegistry.defaultRegistry
-      .getSampleValue(s"${name}_sum", Array("namespace", "action"), Array(namespace, action))
+      .getSampleValue(s"${name}_sum", Array("namespace", "initiator", "action"), Array(namespace, initiator, action))
       .doubleValue()
 }


### PR DESCRIPTION
This PR uses `Duration` type for time units in `Activation`. 

* The deserialization logic takes care of mapping negative values to zero duration
* Uses `toUnit` method duration to convert to seconds with `Double` precision

This should help in fixing #40 and #39 and ensures that we interpret the duration values in a consistent way