### PR TITLE
Emit metrics related to hitting user limits

### DIFF
--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonRecorder.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonRecorder.scala
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 
 package com.adobe.api.platform.runtime.metrics
 
+import akka.event.slf4j.SLF4JLogging
 import com.adobe.api.platform.runtime.metrics.Activation.getNamespaceAndActionName
 import kamon.Kamon
 import kamon.metric.MeasurementUnit
@@ -25,25 +26,45 @@ trait KamonMetricNames extends MetricNames {
   val initTimeMetric = "openwhisk.action.initTime"
   val durationMetric = "openwhisk.action.duration"
   val statusMetric = "openwhisk.action.status"
+
+  val concurrentLimitMetric = "openwhisk.action.limit.concurrent"
+  val timedLimitMetric = "openwhisk.action.limit.timed"
 }
 
-object KamonRecorder extends MetricRecorder with KamonMetricNames {
-  private val metrics = new TrieMap[String, ActivationKamonMetrics]
+object KamonRecorder extends MetricRecorder with KamonMetricNames with SLF4JLogging {
+  private val activationMetrics = new TrieMap[String, ActivationKamonMetrics]
+  private val limitMetrics = new TrieMap[String, LimitKamonMetrics]
 
   override def processActivation(activation: Activation, initiatorNamespace: String): Unit = {
     lookup(activation, initiatorNamespace).record(activation)
   }
 
-  override def processMetric(metric: Metric, initiatorNamespace: String): Unit = ???
+  override def processMetric(metric: Metric, initiatorNamespace: String): Unit = {
+    val limitMetric = limitMetrics.getOrElseUpdate(initiatorNamespace, LimitKamonMetrics(initiatorNamespace))
+    limitMetric.record(metric)
+  }
 
   def lookup(activation: Activation, initiatorNamespace: String): ActivationKamonMetrics = {
     val name = activation.name
     val kind = activation.kind
     val memory = activation.memory.toString
-    metrics.getOrElseUpdate(name, {
+    activationMetrics.getOrElseUpdate(name, {
       val (namespace, action) = getNamespaceAndActionName(name)
       ActivationKamonMetrics(namespace, action, kind, memory, initiatorNamespace)
     })
+  }
+
+  case class LimitKamonMetrics(namespace: String) {
+    private val concurrentLimit = Kamon.counter(concurrentLimitMetric).refine(`actionNamespace` -> namespace)
+    private val timedLimit = Kamon.counter(timedLimitMetric).refine(`actionNamespace` -> namespace)
+
+    def record(m: Metric): Unit = {
+      m.metricName match {
+        case "ConcurrentRateLimit" => concurrentLimit.increment()
+        case "TimedRateLimit"      => timedLimit.increment()
+        case x                     => log.warn(s"Unknown limit $x")
+      }
+    }
   }
 
   case class ActivationKamonMetrics(namespace: String,

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonRecorder.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonRecorder.scala
@@ -30,9 +30,11 @@ trait KamonMetricNames extends MetricNames {
 object KamonRecorder extends MetricRecorder with KamonMetricNames {
   private val metrics = new TrieMap[String, ActivationKamonMetrics]
 
-  def processEvent(activation: Activation, initiatorNamespace: String): Unit = {
+  override def processActivation(activation: Activation, initiatorNamespace: String): Unit = {
     lookup(activation, initiatorNamespace).record(activation)
   }
+
+  override def processMetric(metric: Metric, initiatorNamespace: String): Unit = ???
 
   def lookup(activation: Activation, initiatorNamespace: String): ActivationKamonMetrics = {
     val name = activation.name

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonRecorder.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/KamonRecorder.scala
@@ -28,23 +28,27 @@ trait KamonMetricNames extends MetricNames {
 }
 
 object KamonRecorder extends MetricRecorder with KamonMetricNames {
-  private val metrics = new TrieMap[String, KamonMetrics]
+  private val metrics = new TrieMap[String, ActivationKamonMetrics]
 
   def processEvent(activation: Activation, initiatorNamespace: String): Unit = {
     lookup(activation, initiatorNamespace).record(activation)
   }
 
-  def lookup(activation: Activation, initiatorNamespace: String): KamonMetrics = {
+  def lookup(activation: Activation, initiatorNamespace: String): ActivationKamonMetrics = {
     val name = activation.name
     val kind = activation.kind
     val memory = activation.memory.toString
     metrics.getOrElseUpdate(name, {
       val (namespace, action) = getNamespaceAndActionName(name)
-      KamonMetrics(namespace, action, kind, memory, initiatorNamespace)
+      ActivationKamonMetrics(namespace, action, kind, memory, initiatorNamespace)
     })
   }
 
-  case class KamonMetrics(namespace: String, action: String, kind: String, memory: String, initiator: String) {
+  case class ActivationKamonMetrics(namespace: String,
+                                    action: String,
+                                    kind: String,
+                                    memory: String,
+                                    initiator: String) {
     private val activationTags =
       Map(
         `actionNamespace` -> namespace,

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/MetricNames.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/MetricNames.scala
@@ -26,4 +26,7 @@ trait MetricNames {
   def initTimeMetric: String
   def durationMetric: String
   def statusMetric: String
+
+  def concurrentLimitMetric: String
+  def timedLimitMetric: String
 }

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorder.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorder.scala
@@ -15,6 +15,7 @@ import java.io.StringWriter
 import java.util
 import java.util.concurrent.TimeUnit
 
+import akka.event.slf4j.SLF4JLogging
 import akka.http.scaladsl.model.{HttpEntity, MessageEntity}
 import akka.stream.scaladsl.{Concat, Source}
 import akka.util.ByteString
@@ -35,17 +36,27 @@ trait PrometheusMetricNames extends MetricNames {
   val durationMetric = "openwhisk_action_duration_seconds"
   val statusMetric = "openwhisk_action_status"
   val memoryMetric = "openwhisk_action_memory"
+
+  val concurrentLimitMetric = "openwhisk_action_limit_concurrent_total"
+  val timedLimitMetric = "openwhisk_action_limit_timed_total"
 }
 
-case class PrometheusRecorder(kamon: PrometheusReporter) extends MetricRecorder with PrometheusExporter {
+case class PrometheusRecorder(kamon: PrometheusReporter)
+    extends MetricRecorder
+    with PrometheusExporter
+    with SLF4JLogging {
   import PrometheusRecorder._
-  private val metrics = new TrieMap[String, ActivationPromMetrics]
+  private val activationMetrics = new TrieMap[String, ActivationPromMetrics]
+  private val limitMetrics = new TrieMap[String, LimitPromMetrics]
 
   override def processActivation(activation: Activation, initiatorNamespace: String): Unit = {
     lookup(activation, initiatorNamespace).record(activation)
   }
 
-  override def processMetric(metric: Metric, initiatorNamespace: String): Unit = ???
+  override def processMetric(metric: Metric, initiatorNamespace: String): Unit = {
+    val limitMetric = limitMetrics.getOrElseUpdate(initiatorNamespace, LimitPromMetrics(initiatorNamespace))
+    limitMetric.record(metric)
+  }
 
   override def getReport(): MessageEntity =
     HttpEntity(PrometheusExporter.textV4, createSource())
@@ -55,10 +66,23 @@ case class PrometheusRecorder(kamon: PrometheusReporter) extends MetricRecorder 
     val name = activation.name
     val kind = activation.kind
     val memory = activation.memory.toString
-    metrics.getOrElseUpdate(name, {
+    activationMetrics.getOrElseUpdate(name, {
       val (namespace, action) = getNamespaceAndActionName(name)
       ActivationPromMetrics(namespace, action, kind, memory, initiatorNamespace)
     })
+  }
+
+  case class LimitPromMetrics(namespace: String) {
+    private val concurrentLimit = concurrentLimitCounter.labels(namespace)
+    private val timedLimit = timedLimitCounter.labels(namespace)
+
+    def record(m: Metric): Unit = {
+      m.metricName match {
+        case "ConcurrentRateLimit" => concurrentLimit.inc()
+        case "TimedRateLimit"      => timedLimit.inc()
+        case x                     => log.warn(s"Unknown limit $x")
+      }
+    }
   }
 
   case class ActivationPromMetrics(namespace: String,
@@ -181,6 +205,15 @@ object PrometheusRecorder extends PrometheusMetricNames {
       actionNamespace,
       initiatorNamespace,
       actionName)
+
+  private val concurrentLimitCounter =
+    counter(concurrentLimitMetric, "a user has exceeded its limit for concurrent invocations", actionNamespace)
+
+  private val timedLimitCounter =
+    counter(
+      timedLimitMetric,
+      "the user has reached its per minute limit for the number of invocations",
+      actionNamespace)
 
   private def counter(name: String, help: String, tags: String*) =
     Counter

--- a/src/main/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorder.scala
+++ b/src/main/scala/com/adobe/api/platform/runtime/metrics/PrometheusRecorder.scala
@@ -41,9 +41,11 @@ case class PrometheusRecorder(kamon: PrometheusReporter) extends MetricRecorder 
   import PrometheusRecorder._
   private val metrics = new TrieMap[String, ActivationPromMetrics]
 
-  def processEvent(activation: Activation, initiatorNamespace: String): Unit = {
+  override def processActivation(activation: Activation, initiatorNamespace: String): Unit = {
     lookup(activation, initiatorNamespace).record(activation)
   }
+
+  override def processMetric(metric: Metric, initiatorNamespace: String): Unit = ???
 
   override def getReport(): MessageEntity =
     HttpEntity(PrometheusExporter.textV4, createSource())


### PR DESCRIPTION
So far user-events module captures metrics per action/namespace for activation metrics. With this PR it would now also capture metrics related to [namespace limits](https://github.com/apache/openwhisk/blob/master/docs/metrics.md#user-specific-metrics)