### PR TITLE
Move user event specific conf to reference.conf

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -42,16 +42,3 @@ kamon {
     service = "user-events"
   }
 }
-
-user-events {
-  # Server port
-  port = 9095
-
-  # Enables KamonRecorder so as to enable sending metrics to Kamon supported backends
-  # like DataDog
-  enable-kamon = false
-
-  # Namespaces that should not be monitored
-  ignored-namespaces = []
-
-}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -7,9 +7,14 @@
 #the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
 #OF ANY KIND, either express or implied. See the License for the specific language
 #governing permissions and limitations under the License.
-
-
 user-events {
+  # Server port
+  port = 9095
+
+  # Enables KamonRecorder so as to enable sending metrics to Kamon supported backends
+  # like DataDog
+  enable-kamon = false
+
   # Namespaces that should not be monitored
-  ignored-namespaces = ["guest"]
+  ignored-namespaces = []
 }


### PR DESCRIPTION
Having same config in 2 application.conf may cause issue as both files would be picked up during load and depending on the order they get picked up the loaded values would differ.

Instead we should place all config specific to `user-events` in reference.conf and then override specific config in application.conf in test.

See [loading order][1] of configs

[1]: https://github.com/lightbend/config#standard-behavior